### PR TITLE
feat: Add detailed info for ChatGPT agent

### DIFF
--- a/agents.json
+++ b/agents.json
@@ -168,20 +168,28 @@
     },
     {
       "name": "ChatGPT agent",
-      "website": "",
-      "developer": "",
-      "key_features": [],
-      "supported_models": [],
-      "pricing_model": "",
+      "website": "https://openai.com/index/introducing-chatgpt-agent/",
+      "developer": "OpenAI",
+      "key_features": [
+        "Iterative and collaborative workflows",
+        "Interruptible for real-time clarification",
+        "Deep Research for multi-step research and report generation",
+        "Operator for remote visual browser-based task execution",
+        "Terminal tool for code execution and data analysis"
+      ],
+      "supported_models": [
+        "Latest models available to ChatGPT users"
+      ],
+      "pricing_model": "Subscription-based with usage limits (Pro: 400 messages/month, Plus: 40 messages/month)",
       "benchmarks": {
         "swe_bench_score": null,
         "task_success_rate": null,
         "resource_usage": ""
       },
       "qualitative_assessment": {
-        "ease_of_use": null,
-        "documentation_quality": null,
-        "onboarding_experience": ""
+        "ease_of_use": 5,
+        "documentation_quality": 4,
+        "onboarding_experience": "Easy activation through 'Agent mode' or slash command (/agent) in the ChatGPT interface."
       }
     },
     {

--- a/agents/ChatGPT_agent/profile.md
+++ b/agents/ChatGPT_agent/profile.md
@@ -1,0 +1,32 @@
+# ChatGPT Agent
+
+**Developer:** OpenAI
+
+**Website:** [https://openai.com/index/introducing-chatgpt-agent/](https://openai.com/index/introducing-chatgpt-agent/)
+
+## Key Features
+
+*   **Iterative and Collaborative Workflows:** Designed for interactive sessions where users can guide and refine the agent's work.
+*   **Interruptible:** Users can pause the agent at any point to provide clarification or change the direction of the task.
+*   **Deep Research:** Capable of conducting multi-step research tasks and compiling the findings into comprehensive reports.
+*   **Operator:** Can interact with websites and applications through a remote visual browser environment to complete tasks.
+*   **Terminal Tool:** Provides a sandboxed terminal environment for executing code, performing data analysis, and generating files like slides or spreadsheets.
+
+## Supported Models
+
+The ChatGPT agent is a feature within the ChatGPT product and uses the latest models available to ChatGPT users. It is accessible on web, mobile (iOS/Android), and desktop (macOS/Windows) platforms.
+
+## Pricing Model
+
+The ChatGPT agent's usage is tied to a user's ChatGPT subscription plan, with monthly message limits:
+
+*   **Pro Plan:** 400 messages per month.
+*   **Plus Plan:** 40 messages per month or an equivalent cost in credits under a flexible pricing model.
+
+Only user-initiated messages that advance the agent's task count towards this limit.
+
+## Qualitative Assessment
+
+*   **Ease of Use:** The agent is designed to be highly interactive and user-friendly, allowing for natural language instructions and real-time adjustments.
+*   **Documentation Quality:** OpenAI provides official documentation through its Help Center, including articles specifically about the ChatGPT agent.
+*   **Onboarding Experience:** The agent can be easily activated within the ChatGPT interface by selecting "Agent mode" or using a slash command (`/agent`).


### PR DESCRIPTION
I've added comprehensive information for the ChatGPT agent based on my online research.

- I populated the `agents/ChatGPT_agent/profile.md` with key features, pricing, and other qualitative details.
- I updated the corresponding entry in `agents.json` to reflect the new information, including website, developer, features, and pricing model.