### PR TITLE
Add OpenAI Codex and Perplexity Labs profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following agents have been profiled in this repository:
 - Gemini CLI
 - Qwen CLI
 - LogiQCLI
+- OpenAI Codex
 
 ### IDE-Embedded Agents
 - Roo Code
@@ -37,6 +38,7 @@ The following agents have been profiled in this repository:
 - devin
 - manus
 - Minimax agent
+- Perplexity Labs
 
 ### Agent Frameworks
 - CrewAI

--- a/agents.json
+++ b/agents.json
@@ -27,7 +27,7 @@
       "benchmarks": {
         "swe_bench_score": 49,
         "swe_bench_source": "https://www.anthropic.com/research/swe-bench-sonnet",
-        "terminal_bench_score": "43.2% \u00b1 1.3",
+        "terminal_bench_score": "43.2% ± 1.3",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard",
         "task_success_rate": null,
         "resource_usage": "Claude 2 (assisted) scored 4.80% on SWE-bench"
@@ -57,7 +57,7 @@
       ],
       "pricing_model": "Requires an OpenAI API key or a paid OpenAI account (Plus/Pro).",
       "benchmarks": {
-        "terminal_bench_score": "20.0% \u00b1 1.5",
+        "terminal_bench_score": "20.0% ± 1.5",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard",
         "task_success_rate": null,
         "resource_usage": ""
@@ -111,7 +111,7 @@
       ],
       "pricing_model": "Open-source",
       "benchmarks": {
-        "terminal_bench_score": "42.0% \u00b1 1.3",
+        "terminal_bench_score": "42.0% ± 1.3",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard",
         "task_success_rate": null,
         "resource_usage": ""
@@ -201,6 +201,30 @@
         "task_success_rate": null,
         "resource_usage": "",
         "swe_bench_score": "71%"
+      },
+      "qualitative_assessment": {
+        "ease_of_use": null,
+        "documentation_quality": null,
+        "onboarding_experience": null
+      }
+    },
+    {
+      "name": "OpenAI Codex",
+      "website": "https://openai.com/blog/openai-codex",
+      "developer": "OpenAI",
+      "key_features": [
+        "Translates natural language into code",
+        "Supports multiple programming languages",
+        "Available via API or integrated tools"
+      ],
+      "supported_models": [
+        "Codex series (e.g., code-davinci-002, code-cushman-001)"
+      ],
+      "pricing_model": "Usage-based via the OpenAI API",
+      "benchmarks": {
+        "swe_bench_score": null,
+        "task_success_rate": null,
+        "resource_usage": ""
       },
       "qualitative_assessment": {
         "ease_of_use": null,
@@ -933,6 +957,30 @@
         "documentation_quality": null,
         "onboarding_experience": null
       }
+    },
+    {
+      "name": "Perplexity",
+      "website": "https://www.perplexity.ai/",
+      "developer": "Perplexity Labs",
+      "key_features": [
+        "AI-powered search interface",
+        "Provides cited answers from web sources",
+        "Supports follow-up questions and conversations"
+      ],
+      "supported_models": [
+        "Mixture of proprietary and open-source models"
+      ],
+      "pricing_model": "Free tier with optional Pro subscription",
+      "benchmarks": {
+        "swe_bench_score": null,
+        "task_success_rate": null,
+        "resource_usage": ""
+      },
+      "qualitative_assessment": {
+        "ease_of_use": null,
+        "documentation_quality": null,
+        "onboarding_experience": null
+      }
     }
   ],
   "agent_frameworks": [
@@ -1032,7 +1080,7 @@
       ],
       "pricing_model": "Cloud-based platform with a free tier and enterprise options.",
       "benchmarks": {
-        "terminal_bench_score": "42.5% \u00b1 0.8",
+        "terminal_bench_score": "42.5% ± 0.8",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard"
       },
       "qualitative_assessment": {
@@ -1082,7 +1130,7 @@
       ],
       "pricing_model": "Not specified, but seems to be part of the Daytona platform.",
       "benchmarks": {
-        "terminal_bench_score": "41.3% \u00b1 0.7",
+        "terminal_bench_score": "41.3% ± 0.7",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard",
         "task_success_rate": null,
         "resource_usage": ""
@@ -1142,7 +1190,7 @@
       ],
       "pricing_model": "Research project, likely free to use.",
       "benchmarks": {
-        "terminal_bench_score": "39.9% \u00b1 1.0",
+        "terminal_bench_score": "39.9% ± 1.0",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard",
         "task_success_rate": null,
         "resource_usage": ""

--- a/agents/OpenAI_Codex/profile.md
+++ b/agents/OpenAI_Codex/profile.md
@@ -1,0 +1,27 @@
+# OpenAI Codex
+
+## Overview
+OpenAI Codex is a descendant of GPT-3 that translates natural language into code.
+
+## Key Information
+- **Developer:** OpenAI
+- **Website:** [https://openai.com/blog/openai-codex](https://openai.com/blog/openai-codex)
+- **Pricing:** Usage-based via the OpenAI API
+
+## Key Features
+- Translates natural language into code
+- Supports multiple programming languages
+- Available via API or integrated tools
+
+## Supported Models
+- Codex series (e.g., code-davinci-002, code-cushman-001)
+
+## Benchmarks
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+- **Ease of Use:** Not evaluated
+- **Documentation Quality:** Not evaluated
+- **Onboarding Experience:** Not evaluated

--- a/agents/Perplexity_Labs/profile.md
+++ b/agents/Perplexity_Labs/profile.md
@@ -1,0 +1,27 @@
+# Perplexity Labs
+
+## Overview
+Perplexity is an AI-powered search engine that answers questions with cited sources.
+
+## Key Information
+- **Developer:** Perplexity Labs
+- **Website:** [https://www.perplexity.ai/](https://www.perplexity.ai/)
+- **Pricing:** Free tier with optional Pro subscription
+
+## Key Features
+- Real-time web search with conversational answers
+- Provides citations for sources
+- Supports follow-up questions and multi-turn dialogue
+
+## Supported Models
+- Mixture of proprietary and open-source models
+
+## Benchmarks
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+- **Ease of Use:** Not evaluated
+- **Documentation Quality:** Not evaluated
+- **Onboarding Experience:** Not evaluated


### PR DESCRIPTION
## Summary
- add OpenAI Codex profile and data
- add Perplexity Labs profile and data
- list both agents in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68959542d4208321b38fb623671ba0b7