### PR TITLE
Expand AI agent leaderboard docs

### DIFF
--- a/ai_agent_leaderboards/galileo_ai_agent_leaderboard.md
+++ b/ai_agent_leaderboards/galileo_ai_agent_leaderboard.md
@@ -26,3 +26,21 @@ This leaderboard evaluates the performance of various AI models on a range of ta
 | nova-lite-v1 | Amazon | 0.16 | 0.55 | 0.0031 | Proprietary |
 | magistral-small-2506 | Mistral | 0.16 | 0.53 | 0.0301 | Open source |
 | mistral-medium-2505 | Mistral | 0.16 | 0.52 | 0.0293 | Proprietary |
+
+## Overview
+
+An evaluation framework for AI agents across real-world business scenarios. The project offers two versions: v1 for tool-calling performance and v2 with synthetic dataset generation and a simulation engine for evaluating task completion and tool use.
+
+## Version 2 Features
+
+- Dataset generation combining tools, personas, and scenarios across domains.
+- Agent evaluation that simulates conversations to assess performance.
+- Results analysis that aggregates metrics such as action completion and tool selection quality.
+
+## Environment Setup
+
+Version 2 targets Python 3.12 and requires API keys for providers such as OpenAI and Anthropic. Install dependencies inside the `v2` directory with:
+
+```bash
+pip install -r requirements.txt
+```

--- a/ai_agent_leaderboards/swe_bench_leaderboard.md
+++ b/ai_agent_leaderboards/swe_bench_leaderboard.md
@@ -42,6 +42,15 @@ The "Lite" benchmark is a smaller subset of 300 issues for faster evaluation. Th
 
 The full SWE-bench benchmark consists of 2,294 issues. There is no public leaderboard for the full benchmark. However, the `README.md` of the SWE-bench repository states that **SWE-agent** is the "state-of-the-art" on the full test set. A previous search result snippet mentioned a score of **12.47%** for SWE-agent.
 
+## Recent News
+
+- Jan. 13, 2025: Integrated SWE-bench Multimodal with a private test split and sb-cli submission.
+- Jan. 11, 2025: Modal support enables cloud-based evaluations.
+- Aug. 13, 2024: Released SWE-bench Verified, a set of 500 human-validated problems.
+- Jun. 27, 2024: Transitioned to a containerized evaluation harness using Docker.
+- Apr. 2, 2024: Released SWE-agent, achieving state-of-the-art results on the full test set.
+- Jan. 16, 2024: SWE-bench accepted to ICLR 2024 as an oral presentation.
+
 ## Conclusion on SWE-bench data
 
 The SWE-bench leaderboard data is fragmented and not fully public. The most reliable data is for the "Verified" benchmark. For the "Lite" and "Full" benchmarks, only partial data is available. The evaluation for the main benchmark seems to be private, with submissions handled via a command-line tool (`sb-cli`). This makes a complete and up-to-date comparison difficult.

--- a/ai_agent_leaderboards/terminal_bench_leaderboard.md
+++ b/ai_agent_leaderboards/terminal_bench_leaderboard.md
@@ -33,3 +33,17 @@ Terminal-Bench is a benchmark that evaluates AI agents on their ability to perfo
 | 23 | Codex CLI | gpt-4.1 | 2025-05-15 | OpenAI | OpenAI | 8.3% ± 1.4 |
 | 24 | Terminus 1 | Qwen3-235B | 2025-05-15 | Stanford | Alibaba | 6.6% ± 1.4 |
 | 25 | Terminus 1 | DeepSeek-R1 | 2025-05-15 | Stanford | DeepSeek | 5.7% ± 0.7 |
+
+## About Terminal-Bench
+
+Terminal-Bench evaluates AI agents in real terminal environments, covering tasks such as compiling code, training models, and setting up servers. The suite consists of a dataset of tasks and an execution harness that connects a language model to a sandboxed terminal.
+
+## Quickstart
+
+Install the CLI with:
+
+```bash
+uv tool install terminal-bench
+```
+
+Further installation and contribution details are available in the official documentation.


### PR DESCRIPTION
## Summary
- expand Galileo AI Agent Leaderboard with overview, version 2 features, and environment setup guidance
- describe Terminal-Bench and add quickstart instructions
- add recent news highlights to SWE-bench Leaderboard

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68959f436ddc8321939c6dadf8510801