### PR TITLE
Add latest SWE-bench leaderboard data

### DIFF
--- a/ai_agent_leaderboards/swe_bench_leaderboard.md
+++ b/ai_agent_leaderboards/swe_bench_leaderboard.md
@@ -1,56 +1,185 @@
 # SWE-bench Leaderboard
 
-SWE-bench is a benchmark for evaluating large language models on real-world software issues collected from GitHub. The leaderboard is not available as a single, public file and appears to be maintained as a private service with results displayed on a dynamic website. The following is a summary of the available data from the SWE-bench website, its GitHub repository, and related announcements.
+SWE-bench evaluates language models on real-world GitHub issues. The official leaderboard is hosted at [https://www.swebench.com/](https://www.swebench.com/).
 
-**Link to leaderboard:** [https://www.swebench.com/](https://www.swebench.com/)
+## Model Leaderboard (Release 1.0.0)
+
+| Model | % Resolved | Org | Date | Logs | Trajs | Site | Release |
+|---|---|---|---|---|---|---|---|
+| Claude 4 Opus (20250514) | 67.60 |  | 2025-08-02 | ✓ | ✓ |  | 1.0.0 |
+| Claude 4 Sonnet (20250514) | 64.93 |  | 2025-05-21 | ✓ | ✓ |  | 1.0.0 |
+| o3 (2025-04-16) | 58.40 |  | 2025-05-21 | ✓ | ✓ |  | 1.0.0 |
+| Qwen3-Coder 480B/A35B Instruct | 55.40 |  | 2025-08-02 | ✓ | ✓ |  | 1.0.0 |
+| Gemini 2.5 Pro (2025-05-06) | 53.60 |  | 2025-05-21 | ✓ | ✓ |  | 1.0.0 |
+| Claude 3.7 Sonnet (20250219) | 52.80 |  | 2025-05-21 | ✓ | ✓ |  | 0.0.0 |
+| o4-mini (2025-04-16) | 45.00 |  | 2025-05-21 | ✓ | ✓ |  | 1.0.0 |
+| GPT-4.1 (2025-04-14) | 39.58 |  | 2025-05-21 | ✓ | ✓ |  | 1.0.0 |
+| Gemini 2.5 Flash (2025-04-17) | 28.73 |  | 2025-05-21 | ✓ | ✓ |  | 1.0.0 |
+| GPT-4.1-mini (2025-04-14) | 23.94 |  | 2025-05-21 | ✓ | ✓ |  | 0.0.0 |
+| GPT-4o (2024-11-20) | 21.62 |  | 2025-05-21 | ✓ | ✓ |  | 0.0.0 |
+| Llama 4 Maverick Instruct | 21.04 |  | 2025-05-21 | ✓ | ✓ |  | 0.0.0 |
+| Gemini 2.0 flash | 13.52 |  | 2025-05-21 | ✓ | ✓ |  | 0.0.0 |
+| Llama 4 Scout Instruct | 9.06 |  | 2025-05-21 | ✓ | ✓ |  | 0.0.0 |
+| Qwen2.5-Coder 32B Instruct | 9.00 |  | 2025-08-03 | ✓ | ✓ |  | 1.0.0 |
 
 ## SWE-bench Verified
 
-The "Verified" benchmark is a human-validated subset of 500 issues. The leaderboard for this benchmark is the most complete one that is publicly visible.
-
-| Agent | % Resolved |
-|---|---|
-| mini-SWE-agent | up to 65% |
-| Refact.ai Agent | 60.00 |
-| SWE-agent + Claude 4 Sonnet | 56.67 |
-| Isoform | 55.00 |
-| Moatless Tools + Claude 3.5 Sonnet (20241022) | 39.00 |
-| Moatless Tools + Claude 3.5 Sonnet (20241022) | 38.33 |
-| Honeycomb | 38.33 |
-
-Other agents mentioned for this benchmark without specific scores:
-* Atlassian Rovo Dev
-* TRAE
-* ExpeRepair-v1.0 + Claude 4 Sonnet
-* GUIRepair + o3
-* Claude 4 Opus
-* SWE-agent
+| Model | % Resolved | Org | Date | Logs | Trajs | Site |
+|---|---|---|---|---|---|---|
+| TRAE | 75.20 |  | 2025-06-12 | ✓ | ✓ |  |
+| Refact.ai Agent | 74.40 |  | 2025-06-03 | ✓ | ✓ |  |
+| Moatless Tools + Claude 4 Sonnet | 70.80 |  | 2025-06-11 | ✓ | ✓ |  |
+| Refact.ai Agent | 70.40 |  | 2025-05-15 | ✓ | ✓ |  |
+| OpenHands + Claude 4 Sonnet | 70.40 |  | 2025-05-24 | ✓ | ✓ |  |
+| Augment Agent v1 | 70.40 |  | 2025-06-10 | ✓ | ✓ |  |
+| mini-SWE-agent + Claude 4 Opus (20250514) | 67.60 |  | 2025-08-02 | ✓ | ✓ |  |
+| SWE-agent + Claude 4 Sonnet | 66.60 |  | 2025-05-22 | ✓ | ✓ |  |
+| OpenHands | 65.80 |  | 2025-04-15 | ✓ | ✓ |  |
+| Augment Agent v0 | 65.40 |  | 2025-03-16 | ✓ | ✓ |  |
+| mini-SWE-agent + Claude 4 Sonnet (20250514) | 64.93 |  | 2025-05-21 | ✓ | ✓ |  |
+| PatchPilot-v1.1 | 64.60 |  | 2025-05-03 | ✓ | ✓ | - |
+| SWE-agent + Claude 3.7 Sonnet w/ Review Heavy | 62.40 |  | 2025-02-25 | ✓ | ✓ |  |
+| OpenHands + 4x Scaled (2024-02-03) | 60.80 |  | 2025-02-03 | ✓ | ✓ |  |
+| DeepSWE-Preview | 58.80 |  | 2025-06-29 | ✓ | ✓ |  |
+| mini-SWE-agent + o3 (2025-04-16) | 58.40 |  | 2025-05-21 | ✓ | ✓ |  |
+| SWE-Rizzo | 56.60 | - | 2025-04-05 | ✓ | ✓ |  |
+| mini-SWE-agent + Qwen3-Coder 480B/A35B Instruct | 55.40 |  | 2025-08-02 | ✓ | ✓ |  |
+| mini-SWE-agent + Gemini 2.5 Pro (2025-05-06) | 53.60 |  | 2025-05-21 | ✓ | ✓ |  |
+| OpenHands + CodeAct v2.1 (claude-3-5-sonnet-20241022) | 53.00 |  | 2024-10-29 | ✓ | ✓ |  |
+| mini-SWE-agent + Claude 3.7 Sonnet (20250219) | 52.80 |  | 2025-05-21 | ✓ | ✓ |  |
+| Agentless-1.5 + Claude-3.5 Sonnet (20241022) | 50.80 |  | 2024-12-02 | ✓ | ✓ |  |
+| Composio SWE-Kit (2024-10-25) | 48.60 |  | 2024-10-25 | ✓ | ✓ |  |
+| AppMap Navie v2 | 47.20 |  | 2024-11-06 | ✓ | ✓ |  |
+| Skywork-SWE-32B + TTS(Bo8) | 47.00 |  | 2025-06-16 | ✓ | ✓ |  |
+| OpenHands + DevStral Small 2505 | 46.80 |  | 2025-05-20 | ✓ | ✓ |  |
+| AutoCodeRover-v2.0 (Claude-3.5-Sonnet-20241022) | 46.20 |  | 2024-11-08 | ✓ | ✓ |  |
+| PatchPilot + Co-PatcheR | 46.00 |  | 2025-05-28 | ✓ | ✓ |  |
+| mini-SWE-agent + o4-mini (2025-04-16) | 45.00 |  | 2025-05-21 | ✓ | ✓ |  |
+| Agentless Lite + O3 Mini (20250214) | 42.40 |  | 2025-02-14 | ✓ | ✓ |  |
+| DeepSWE-Preview | 42.20 |  | 2025-06-29 | ✓ | ✓ |  |
+| SWE-RL (Llama3-SWE-RL-70B + Agentless Mini) (20250226) | 41.20 |  | 2025-02-26 | ✓ | ✓ |  |
+| Composio SWEkit + Claude 3.5 Sonnet (2024-10-16) | 40.60 |  | 2024-10-16 | ✓ | ✓ |  |
+| SWE-agent + SWE-agent-LM-32B | 40.20 |  | 2025-05-11 | ✓ | ✓ |  |
+| mini-SWE-agent + GPT-4.1 (2025-04-14) | 39.58 |  | 2025-05-21 | ✓ | ✓ |  |
+| Agentless-1.5 + GPT 4o (2024-05-13) | 38.80 |  | 2024-10-28 | ✓ | ✓ |  |
+| Skywork-SWE-32B | 38.00 |  | 2025-06-16 | ✓ | ✓ |  |
+| SWE-agent + Claude 3.5 Sonnet | 33.60 |  | 2024-06-20 | ✓ | ✓ |  |
+| SWE-Fixer (Qwen2.5-7b retriever + Qwen2.5-72b editor) | 32.80 |  | 2025-03-06 | ✓ | ✓ |  |
+| SWE-Fixer (Qwen2.5-7b retriever + Qwen2.5-72b editor) 20241128 | 30.20 |  | 2024-11-28 | ✓ | ✓ |  |
+| Lingma Agent + Lingma SWE-GPT 72b (v0925) | 28.80 |  | 2024-10-02 | ✓ | ✓ |  |
+| mini-SWE-agent + Gemini 2.5 Flash (2025-04-17) | 28.73 |  | 2025-05-21 | ✓ | ✓ |  |
+| AppMap Navie + GPT 4o (2024-05-13) | 26.20 |  | 2024-06-15 | ✓ | - |  |
+| Lingma Agent + Lingma SWE-GPT 72b (v0918) | 25.00 |  | 2024-09-18 | ✓ | ✓ |  |
+| mini-SWE-agent + GPT-4.1-mini (2025-04-14) | 23.94 |  | 2025-05-21 | ✓ | ✓ |  |
+| MCTS-Refine-7B | 23.20 | - | 2025-06-27 | ✓ | ✓ |  |
+| SWE-agent + GPT 4o (2024-05-13) | 23.20 |  | 2024-07-28 | ✓ | ✓ |  |
+| SWE-agent + GPT 4 (1106) | 22.40 |  | 2024-04-02 | ✓ | ✓ |  |
+| mini-SWE-agent + GPT-4o (2024-11-20) | 21.62 |  | 2025-05-21 | ✓ | ✓ |  |
+| mini-SWE-agent + Llama 4 Maverick Instruct | 21.04 |  | 2025-05-21 | ✓ | ✓ |  |
+| SWE-agent + Claude 3 Opus | 18.20 |  | 2024-04-02 | ✓ | ✓ |  |
+| Lingma Agent + Lingma SWE-GPT 7b (v0925) | 18.20 |  | 2024-10-02 | ✓ | ✓ |  |
+| mini-SWE-agent + Gemini 2.0 flash | 13.52 |  | 2025-05-21 | ✓ | ✓ |  |
+| Lingma Agent + Lingma SWE-GPT 7b (v0918) | 10.20 |  | 2024-09-18 | ✓ | ✓ |  |
+| mini-SWE-agent + Llama 4 Scout Instruct | 9.06 |  | 2025-05-21 | ✓ | ✓ |  |
+| mini-SWE-agent + Qwen2.5-Coder 32B Instruct | 9.00 |  | 2025-08-03 | ✓ | ✓ |  |
+| RAG + Claude 3 Opus | 7.00 |  | 2024-04-02 | ✓ | - |  |
+| RAG + Claude 2 | 4.40 |  | 2023-10-10 | ✓ | - | - |
+| RAG + GPT 4 (1106) | 2.80 |  | 2024-04-02 | ✓ | - | - |
+| RAG + SWE-Llama 7B | 1.40 |  | 2023-10-10 | ✓ | - | - |
+| RAG + SWE-Llama 13B | 1.20 |  | 2023-10-10 | ✓ | - | - |
+| RAG + ChatGPT 3.5 | 0.40 |  | 2023-10-10 | ✓ | - | - |
 
 ## SWE-bench Lite
 
-The "Lite" benchmark is a smaller subset of 300 issues for faster evaluation. The following data is from a bar chart on the SWE-bench website.
+| Model | % Resolved | Org | Date | Logs | Trajs | Site |
+|---|---|---|---|---|---|---|
+| ExpeRepair-v1.0 + Claude 4 Sonnet | 60.33 |  | 2025-06-25 | ✓ | ✓ |  |
+| Refact.ai Agent | 60.00 |  | 2025-04-25 | ✓ | ✓ |  |
+| SWE-agent + Claude 4 Sonnet | 56.67 |  | 2025-05-26 | ✓ | ✓ |  |
+| ExpeRepair-v1.0 | 48.33 |  | 2025-06-13 | ✓ | ✓ |  |
+| SWE-agent + Claude 3.7 Sonnet | 48.00 |  | 2025-02-26 | ✓ | ✓ |  |
+| DARS Agent | 47.00 |  | 2025-02-05 | ✓ | ✓ |  |
+| KGCompass + Claude 3.5 Sonnet (20241022) | 46.00 |  | 2025-06-19 | ✓ | ✓ |  |
+| CodeFuse-CGM | 44.00 |  | 2025-03-10 | ✓ | ✓ |  |
+| Lingxi | 42.67 |  | 2025-05-09 | ✓ | ✓ |  |
+| OpenHands + CodeAct v2.1 (claude-3-5-sonnet-20241022) | 41.67 |  | 2024-10-25 | ✓ | ✓ |  |
+| PatchKitty-0.9 + Claude-3.5 Sonnet (20241022) | 41.33 |  | 2024-12-20 | ✓ | ✓ | - |
+| OrcaLoca + Agentless-1.5 + Claude-3.5 Sonnet (20241022) | 41.00 |  | 2025-01-13 | - | - |  |
+| Composio SWE-Kit (2024-10-30) | 41.00 |  | 2024-10-30 | ✓ | ✓ |  |
+| Moatless Tools + Claude 3.5 Sonnet (20241022) | 39.00 | - | 2025-01-14 | ✓ | ✓ |  |
+| Moatless Tools + Claude 3.5 Sonnet (20241022) | 38.33 | - | 2024-11-17 | ✓ | ✓ |  |
+| Patched.Codes Patchwork | 37.00 |  | 2025-01-04 | ✓ | ✓ |  |
+| KGCompass + DeepSeek V3 | 36.67 |  | 2025-06-09 | ✓ | ✓ |  |
+| AppMap Navie v2 | 36.00 |  | 2024-11-13 | ✓ | ✓ |  |
+| Alibaba Lingma Agent | 33.00 |  | 2024-06-22 | ✓ | ✓ |  |
+| Agentless Lite + O3 Mini (20250214) | 32.33 |  | 2025-02-14 | - | - |  |
+| Agentless-1.5 + GPT 4o (2024-05-13) | 32.00 |  | 2024-10-28 | - | - |  |
+| CodeShellTester + GPT 4o (2024-05-13) | 31.33 |  | 2024-11-11 | ✓ | ✓ |  |
+| Moatless Tools + Deepseek V3 | 30.67 | - | 2025-01-11 | ✓ | ✓ |  |
+| AutoCodeRover (v20240620) + GPT 4o (2024-05-13) | 30.67 |  | 2024-06-21 | ✓ | ✓ |  |
+| Aegis - o3-mini_1.0 | 30.33 | - | 2025-02-07 | ✓ | ✓ |  |
+| AIGCode Infant-Coder(2024-08-30) | 30.00 | - | 2024-09-08 | ✓ | ✓ |  |
+| Agentless + RepoGraph + GPT-4o | 29.67 |  | 2024-08-08 | ✓ | ✓ |  |
+| CodeR + GPT 4 (1106) | 28.33 |  | 2024-06-04 | ✓ | ✓ |  |
+| SIMA + GPT 4o (2024-05-13) | 27.67 | - | 2024-07-06 | ✓ | ✓ |  |
+| Agentless + GPT 4o (2024-05-13) | 27.33 |  | 2024-06-30 | ✓ | - |  |
+| Moatless Tools + Claude 3.5 Sonnet | 26.67 | - | 2024-06-23 | ✓ | ✓ |  |
+| OpenHands + CodeAct v1.8 | 26.67 |  | 2024-07-25 | ✓ | ✓ |  |
+| Aider + GPT 4o & Claude 3 Opus | 26.33 |  | 2024-05-23 | ✓ | - |  |
+| SWE-Fixer (Qwen2.5-7b retriever + Qwen2.5-72b editor) | 24.67 |  | 2025-03-06 | ✓ | ✓ |  |
+| SWE-Fixer (Qwen2.5-7b retriever + Qwen2.5-72b editor) 20241128 | 23.33 |  | 2024-11-28 | ✓ | ✓ |  |
+| SWE-agent + Claude 3.5 Sonnet | 23.00 |  | 2024-06-20 | ✓ | ✓ |  |
+| AppMap Navie + GPT 4o (2024-05-13) | 21.67 |  | 2024-06-15 | ✓ | - |  |
+| AutoCodeRover (v20240408) + GPT 4 (0125) | 19.00 |  | 2024-05-30 | ✓ | - |  |
+| SWE-agent + GPT 4o (2024-05-13) | 18.33 |  | 2024-07-28 | ✓ | ✓ |  |
+| SWE-agent + GPT 4 (1106) | 18.00 |  | 2024-04-02 | ✓ | ✓ |  |
+| MCTS-Refine-7B | 16.33 | - | 2025-06-27 | ✓ | ✓ |  |
+| SWE-agent + Claude 3 Opus | 11.67 |  | 2024-04-02 | ✓ | ✓ |  |
+| RAG + Claude 3 Opus | 4.33 |  | 2024-04-02 | ✓ | - |  |
+| RAG + Claude 2 | 3.00 |  | 2023-10-10 | ✓ | ✓ |  |
+| RAG + GPT 4 (1106) | 2.67 |  | 2024-04-02 | ✓ | - |  |
+| RAG + SWE-Llama 7B | 1.33 |  | 2023-10-10 | ✓ | - |  |
+| RAG + SWE-Llama 13B | 1.00 |  | 2023-10-10 | ✓ | - |  |
+| RAG + ChatGPT 3.5 | 0.33 |  | 2023-10-10 | ✓ | - |  |
 
-| Agent | % Resolved (approx.) |
-|---|---|
-| Claude-2 | 3.3% |
-| SWE-Llama 7b | 1.2% |
-| SWE-Llama 13b | 1.2% |
-| GPT-3.5 | 0.3% |
-| GPT-4 | 0% |
+## SWE-bench Full
 
-## SWE-bench (Full)
+| Model | % Resolved | Org | Date | Logs | Trajs | Site |
+|---|---|---|---|---|---|---|
+| SWE-agent 1.0 (Claude 3.7 Sonnet) | 33.83 |  | 2025-02-27 | ✓ | ✓ |  |
+| OpenHands + CodeAct v2.1 (claude-3-5-sonnet-20241022) | 29.38 |  | 2024-11-03 | ✓ | ✓ |  |
+| AutoCodeRover-v2.0 (Claude-3.5-Sonnet-20241022) | 24.89 |  | 2024-11-21 | ✓ | ✓ |  |
+| SWE-agent + Claude 3.5 Sonnet | 18.13 |  | 2024-06-20 | ✓ | ✓ | - |
+| SWE-agent + GPT 4 (1106) | 12.47 |  | 2024-04-02 | ✓ | ✓ |  |
+| SWE-agent + GPT 4o (2024-05-13) | 11.99 |  | 2024-07-28 | ✓ | ✓ |  |
+| SWE-agent + Claude 3 Opus | 10.51 |  | 2024-04-02 | ✓ | ✓ | - |
+| RAG + Claude 3 Opus | 3.79 |  | 2024-04-02 | ✓ | - |  |
+| RAG + Claude 2 | 1.96 |  | 2023-10-10 | ✓ | - | - |
+| RAG + GPT 4 (1106) | 1.31 |  | 2024-04-02 | ✓ | - | - |
+| RAG + SWE-Llama 13B | 0.70 |  | 2023-10-10 | ✓ | - | - |
+| RAG + SWE-Llama 7B | 0.70 |  | 2023-10-10 | ✓ | - | - |
+| RAG + ChatGPT 3.5 | 0.17 |  | 2023-10-10 | ✓ | - | - |
 
-The full SWE-bench benchmark consists of 2,294 issues. There is no public leaderboard for the full benchmark. However, the `README.md` of the SWE-bench repository states that **SWE-agent** is the "state-of-the-art" on the full test set. A previous search result snippet mentioned a score of **12.47%** for SWE-agent.
+## SWE-bench Multimodal
 
-## Recent News
+| Model | % Resolved | Org | Date | Logs | Trajs | Site |
+|---|---|---|---|---|---|---|
+| GUIRepair + o3 (2025-04-16) | 35.98 |  | 2025-07-01 | - | - |  |
+| Refact.ai Agent | 35.59 |  | 2025-06-11 | - | - |  |
+| OpenHands-Versa (Claude-Sonnet 4) | 34.43 |  | 2025-05-28 | - | - |  |
+| GUIRepair + o4-mini (2025-04-16) | 33.85 |  | 2025-05-31 | - | - |  |
+| OpenHands-Versa (Claude-3.7 Sonnet) | 31.33 |  | 2025-05-09 | - | - |  |
+| GUIRepair + GPT 4.1 (2025-04-14) | 31.14 |  | 2025-05-31 | - | - |  |
+| GUIRepair + GPT 4o (2024-08-06) | 30.37 |  | 2025-05-31 | - | - |  |
+| Agentless Lite + Claude-3.5 Sonnet | 25.34 |  | 2025-02-26 | - | - |  |
+| SWE-agent Multimodal + GPT 4o (2024-08-06) | 12.19 |  | 2024-10-06 | - | - |  |
+| SWE-agent + Claude Sonnet 3.5 | 12.19 |  | 2024-10-06 | - | - |  |
+| SWE-agent JavaScript + Claude Sonnet 3.5 | 11.99 |  | 2024-10-06 | - | - |  |
+| SWE-agent + GPT 4o (2024-08-06) | 11.99 |  | 2024-10-06 | - | - |  |
+| SWE-agent Multimodal + Claude 3.5 Sonnet | 11.41 |  | 2024-10-06 | - | - |  |
+| SWE-agent JavaScript + GPT 4o (2024-08-06) | 9.28 |  | 2024-10-06 | - | - |  |
+| Agentless + Claude 3.5 Sonnet | 6.19 |  | 2024-10-06 | - | - |  |
+| RAG + GPT 4o (2024-08-06) | 6.00 |  | 2024-10-06 | - | - |  |
+| RAG + Claude 3.5 Sonnet | 5.03 |  | 2024-10-06 | - | - |  |
+| Agentless + GPT 4o (2024-08-06) | 3.09 |  | 2024-10-06 | - | - |  |
 
-- Jan. 13, 2025: Integrated SWE-bench Multimodal with a private test split and sb-cli submission.
-- Jan. 11, 2025: Modal support enables cloud-based evaluations.
-- Aug. 13, 2024: Released SWE-bench Verified, a set of 500 human-validated problems.
-- Jun. 27, 2024: Transitioned to a containerized evaluation harness using Docker.
-- Apr. 2, 2024: Released SWE-agent, achieving state-of-the-art results on the full test set.
-- Jan. 16, 2024: SWE-bench accepted to ICLR 2024 as an oral presentation.
-
-## Conclusion on SWE-bench data
-
-The SWE-bench leaderboard data is fragmented and not fully public. The most reliable data is for the "Verified" benchmark. For the "Lite" and "Full" benchmarks, only partial data is available. The evaluation for the main benchmark seems to be private, with submissions handled via a command-line tool (`sb-cli`). This makes a complete and up-to-date comparison difficult.


### PR DESCRIPTION
## Summary
- expand SWE-bench leaderboard with release 1.0.0 model results
- include current Verified, Lite, Full and Multimodal benchmark tables

## Testing
- `pytest`
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_6895a5a4e74c8321809de38233a67d22