### PR TITLE
Add user persona tool recommendations

### DIFF
--- a/user_persona_recommendations/beginner_student/profile.md
+++ b/user_persona_recommendations/beginner_student/profile.md
@@ -1,0 +1,9 @@
+# Beginner Student Creator
+
+Students and hobbyists starting their coding journey and eager to learn through experimentation.
+
+## Recommended Tools
+- **Replit_AI** – in-browser development with instant feedback.
+- **CodeWP** – template-driven coding assistance for web projects.
+- **ChatGPT_agent** – interactive explanations of concepts and debugging help.
+- **Tabnine** – lightweight autocompletion for many editors.

--- a/user_persona_recommendations/business_user_automation/profile.md
+++ b/user_persona_recommendations/business_user_automation/profile.md
@@ -1,0 +1,9 @@
+# Business User Automation Seeker
+
+Sales, presales, and management professionals who need to automate reports, presentations, or simple data analysis without becoming full developers.
+
+## Recommended Tools
+- **ChatGPT_agent** – draft presentations and automate document formatting.
+- **Qwen_CLI** – run local data analysis and visualization scripts.
+- **Perplexity_Labs** – gather market research quickly.
+- **SQLAI** – generate and explain database queries for ad hoc reporting.

--- a/user_persona_recommendations/data_scientist/profile.md
+++ b/user_persona_recommendations/data_scientist/profile.md
@@ -1,0 +1,9 @@
+# Data Scientist
+
+Practitioners focused on data pipelines, modeling, and analysis who want AI assistance in research and coding.
+
+## Recommended Tools
+- **LangChain** – build data-aware applications with complex toolchains.
+- **Amazon_CodeWhisperer** – autocomplete for Python notebooks and AWS integration.
+- **SQLAI** – craft efficient queries and understand schema relationships.
+- **Qwen_CLI** – leverage LLMs locally for large dataset experiments.

--- a/user_persona_recommendations/engineering_manager_returning/profile.md
+++ b/user_persona_recommendations/engineering_manager_returning/profile.md
@@ -1,0 +1,9 @@
+# Returning Engineering Manager
+
+A manager who stepped away from daily coding and wants to regain hands-on experience using modern AI tools.
+
+## Recommended Tools
+- **GitHub_Copilot** – quickly recall syntax and patterns with inline guidance.
+- **ChatGPT_agent** – explore architectural questions and generate starting points for tasks.
+- **Sourcegraph_Cody** – search and understand unfamiliar parts of large codebases.
+- **Perplexity_Labs** – research best practices and emerging frameworks.

--- a/user_persona_recommendations/professional_researcher/profile.md
+++ b/user_persona_recommendations/professional_researcher/profile.md
@@ -1,0 +1,9 @@
+# Professional Researcher
+
+Researchers who write papers, analyze literature, and prototype algorithms across domains.
+
+## Recommended Tools
+- **Perplexity_Labs** – comprehensive search over academic sources.
+- **ChatGPT_agent** – summarize papers and draft sections.
+- **LangGraph** – orchestrate experiments involving multiple models and tools.
+- **Sourcegraph_Cody** – explore and reuse research code repositories.

--- a/user_persona_recommendations/self_employed_consultant/profile.md
+++ b/user_persona_recommendations/self_employed_consultant/profile.md
@@ -1,0 +1,9 @@
+# Self-Employed Consultant
+
+Independent professionals who automate workflows to serve more clients efficiently.
+
+## Recommended Tools
+- **LangGraph** – design reusable automation pipelines.
+- **OpenAI_Codex** – generate scripts that integrate with existing tools.
+- **Cursor** – maintain client-specific codebases with AI assistance.
+- **SWE-agent** – plan and execute multi-step coding tasks on behalf of clients.

--- a/user_persona_recommendations/software_engineer_traditional_ide/profile.md
+++ b/user_persona_recommendations/software_engineer_traditional_ide/profile.md
@@ -1,0 +1,9 @@
+# Traditional IDE Software Engineer
+
+Engineers accustomed to Visual Studio, IntelliJ, or similar IDEs who want AI assistance without leaving familiar workflows.
+
+## Recommended Tools
+- **GitHub_Copilot** – inline code suggestions directly in major IDEs.
+- **Sourcegraph_Cody** – deep code understanding and navigation across large codebases.
+- **Cursor** – an AI-first editor that keeps IDE features while enhancing AI-powered refactoring.
+- **Amazon_CodeWhisperer** – integrates with AWS tooling for cloud-centric projects.

--- a/user_persona_recommendations/vibe_coder_entrepreneur/profile.md
+++ b/user_persona_recommendations/vibe_coder_entrepreneur/profile.md
@@ -1,0 +1,9 @@
+# Vibe Coder Entrepreneur
+
+Non-traditional coders building applications to support a business idea with minimal formal training.
+
+## Recommended Tools
+- **Cursor** – intuitive AI coding environment that emphasizes usability.
+- **Claude_Code** – natural language code generation for rapid prototyping.
+- **Replit_AI** – deploy full-stack apps without heavy setup.
+- **Gemini_CLI** – experiment with multimodal inputs for creative features.


### PR DESCRIPTION
## Summary
- add `user_persona_recommendations` directory with profiles for eight distinct personas
- provide personalized AI tool suggestions in each profile

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895aa4915d883219e5c00eef2460020