### PR TITLE
Add chat.z.ai agent profile

### DIFF
--- a/agents.json
+++ b/agents.json
@@ -959,6 +959,34 @@
       }
     },
     {
+      "name": "chat.z.ai",
+      "website": "https://chat.z.ai/",
+      "developer": "Zhipu AI",
+      "key_features": [
+        "Web-based conversational interface for GLM models",
+        "Supports reasoning, coding, and tool use",
+        "128k context length",
+        "Native function calling and plugin support",
+        "Web browsing capabilities",
+        "Full-stack development features"
+      ],
+      "supported_models": [
+        "GLM-4.5",
+        "GLM-4.5-Air"
+      ],
+      "pricing_model": "Freemium/Open-Source",
+      "benchmarks": {
+        "swe_bench_score": 64.2,
+        "task_success_rate": null,
+        "resource_usage": ""
+      },
+      "qualitative_assessment": {
+        "ease_of_use": null,
+        "documentation_quality": null,
+        "onboarding_experience": null
+      }
+    },
+    {
       "name": "Perplexity",
       "website": "https://www.perplexity.ai/",
       "developer": "Perplexity Labs",

--- a/agents/chat.z.ai/profile.md
+++ b/agents/chat.z.ai/profile.md
@@ -1,0 +1,34 @@
+# chat.z.ai
+
+## Basic Info
+
+- **Website:** https://chat.z.ai/
+- **Developer:** Zhipu AI
+
+## Key Features
+
+- Web-based conversational interface for GLM models
+- Supports reasoning, coding, and tool use
+- 128k context length
+- Native function calling and plugin support
+- Web browsing capabilities
+- Full-stack development features
+
+## Supported Models
+
+- GLM-4.5
+- GLM-4.5-Air
+
+## Pricing
+
+- Freemium/Open-Source
+
+## Benchmarks
+
+- **SWE-bench Verified:** 64.2
+
+## Qualitative Assessment
+
+- **Ease of Use:** Information not available in English.
+- **Documentation Quality:** Information not available in English.
+- **Onboarding Experience:** Information not available in English.


### PR DESCRIPTION
## Summary
- document chat.z.ai agent capabilities and metadata
- include chat.z.ai in agents.json catalogue

## Testing
- `python - <<'PY'
import json
from jsonschema import validate
schema = json.load(open('agents.schema.json'))
data = json.load(open('agents.json'))
validate(instance=data, schema=schema)
print('agents.json is valid against agents.schema.json')
PY`
- `npx prettier agents/chat.z.ai/profile.md --write`


------
https://chatgpt.com/codex/tasks/task_e_6895ab85314c8321b367091d0b75badd