### PR TITLE
Expand persona recommendations with criteria and rationale

### DIFF
--- a/user_persona_recommendations/beginner_student/profile.md
+++ b/user_persona_recommendations/beginner_student/profile.md
@@ -2,8 +2,19 @@
 
 Students and hobbyists starting their coding journey and eager to learn through experimentation.
 
+### Key Criteria
+- **Ease of Use** – tools must be simple to set up and operate.
+- **Guided Learning** – built-in explanations or tutorials aid skill growth.
+- **Affordability** – free tiers or low cost for budget-conscious learners.
+
 ## Recommended Tools
 - **Replit_AI** – in-browser development with instant feedback.
 - **CodeWP** – template-driven coding assistance for web projects.
 - **ChatGPT_agent** – interactive explanations of concepts and debugging help.
 - **Tabnine** – lightweight autocompletion for many editors.
+
+## Why These Tools
+- **Replit_AI** keeps everything in the browser, matching the need for ease of use.
+- **CodeWP** offers guided templates that help teach patterns.
+- **ChatGPT_agent** provides conversational learning and answers.
+- **Tabnine** supplies inexpensive autocompletion across environments.

--- a/user_persona_recommendations/business_user_automation/profile.md
+++ b/user_persona_recommendations/business_user_automation/profile.md
@@ -2,8 +2,19 @@
 
 Sales, presales, and management professionals who need to automate reports, presentations, or simple data analysis without becoming full developers.
 
+### Key Criteria
+- **No-Code Accessibility** – automation without traditional programming.
+- **Business Data Integration** – connect to spreadsheets, CRM, and documents.
+- **Productivity Gains** – reduce time spent on routine tasks.
+
 ## Recommended Tools
 - **ChatGPT_agent** – draft presentations and automate document formatting.
-- **Qwen_CLI** – run local data analysis and visualization scripts.
+- **Zapier** – connect services and build workflows without code.
 - **Perplexity_Labs** – gather market research quickly.
 - **SQLAI** – generate and explain database queries for ad hoc reporting.
+
+## Why These Tools
+- **ChatGPT_agent** turns natural language into polished business materials.
+- **Zapier** automates cross-app processes without scripting.
+- **Perplexity_Labs** surfaces up-to-date competitive intel.
+- **SQLAI** empowers non-developers to retrieve data from databases.

--- a/user_persona_recommendations/data_scientist/profile.md
+++ b/user_persona_recommendations/data_scientist/profile.md
@@ -2,8 +2,19 @@
 
 Practitioners focused on data pipelines, modeling, and analysis who want AI assistance in research and coding.
 
+### Key Criteria
+- **Data Pipeline Integration** – compatibility with common data tools and frameworks.
+- **Reproducibility** – support for versioning and experiment tracking.
+- **Scalability** – ability to handle large datasets and complex models.
+
 ## Recommended Tools
 - **LangChain** – build data-aware applications with complex toolchains.
 - **Amazon_CodeWhisperer** – autocomplete for Python notebooks and AWS integration.
 - **SQLAI** – craft efficient queries and understand schema relationships.
 - **Qwen_CLI** – leverage LLMs locally for large dataset experiments.
+
+## Why These Tools
+- **LangChain** orchestrates multi-step data workflows.
+- **Amazon_CodeWhisperer** accelerates notebook coding within AWS ecosystems.
+- **SQLAI** ensures precise querying and schema comprehension.
+- **Qwen_CLI** runs open models locally for scalable experimentation.

--- a/user_persona_recommendations/engineering_manager_returning/profile.md
+++ b/user_persona_recommendations/engineering_manager_returning/profile.md
@@ -2,8 +2,19 @@
 
 A manager who stepped away from daily coding and wants to regain hands-on experience using modern AI tools.
 
+### Key Criteria
+- **Fast Reacclimation** – quickly recall syntax and modern practices.
+- **Codebase Navigation** – understand large or unfamiliar projects.
+- **Architectural Insight** – explore design patterns and trade-offs.
+
 ## Recommended Tools
 - **GitHub_Copilot** – quickly recall syntax and patterns with inline guidance.
 - **ChatGPT_agent** – explore architectural questions and generate starting points for tasks.
 - **Sourcegraph_Cody** – search and understand unfamiliar parts of large codebases.
 - **Perplexity_Labs** – research best practices and emerging frameworks.
+
+## Why These Tools
+- **GitHub_Copilot** jump-starts coding fluency inside editors.
+- **ChatGPT_agent** clarifies design decisions and modern conventions.
+- **Sourcegraph_Cody** reveals context across repositories.
+- **Perplexity_Labs** keeps managers current on technology trends.

--- a/user_persona_recommendations/persona_crieria.md
+++ b/user_persona_recommendations/persona_crieria.md
@@ -1,0 +1,50 @@
+# Persona Criteria
+
+- **Ease of Use** – simple interfaces that require minimal setup.  
+  Important for: Beginner Student Creator
+- **Guided Learning** – built-in tutorials and explanations supporting education.  
+  Important for: Beginner Student Creator
+- **Affordability** – low-cost or free options suitable for tight budgets.  
+  Important for: Beginner Student Creator
+- **No-Code Accessibility** – automate tasks without traditional programming.  
+  Important for: Business User Automation Seeker
+- **Business Data Integration** – connect seamlessly to spreadsheets, CRM systems, and documents.  
+  Important for: Business User Automation Seeker
+- **Productivity Gains** – significantly reduce time spent on routine business tasks.  
+  Important for: Business User Automation Seeker
+- **Data Pipeline Integration** – work smoothly with common data processing frameworks.  
+  Important for: Data Scientist
+- **Reproducibility** – support experiment tracking and version control for reliable results.  
+  Important for: Data Scientist
+- **Scalability** – handle large datasets and complex models efficiently.  
+  Important for: Data Scientist
+- **Fast Reacclimation** – help users regain coding fluency quickly.  
+  Important for: Returning Engineering Manager
+- **Codebase Navigation** – surface relevant context across large or unfamiliar projects.  
+  Important for: Returning Engineering Manager
+- **Architectural Insight** – assist in evaluating design patterns and trade-offs.  
+  Important for: Returning Engineering Manager
+- **Literature Coverage** – provide access to broad and credible academic sources.  
+  Important for: Professional Researcher
+- **Experiment Orchestration** – coordinate multiple models, datasets, and evaluation steps.  
+  Important for: Professional Researcher
+- **Code Reusability** – enable discovery and adaptation of existing research code.  
+  Important for: Professional Researcher
+- **Automation Efficiency** – deliver results with minimal manual intervention.  
+  Important for: Self-Employed Consultant
+- **Client Customization** – easily tailor solutions to diverse client needs.  
+  Important for: Self-Employed Consultant
+- **Reliability** – produce maintainable solutions that run unattended.  
+  Important for: Self-Employed Consultant
+- **IDE Integration** – function as plugins within established development environments.  
+  Important for: Traditional IDE Software Engineer
+- **Code Quality Assurance** – enhance readability and safety of produced code.  
+  Important for: Traditional IDE Software Engineer
+- **Cloud Tooling Alignment** – integrate smoothly with cloud providers and enterprise stacks.  
+  Important for: Traditional IDE Software Engineer
+- **Rapid Prototyping** – move from concept to demo quickly.  
+  Important for: Vibe Coder Entrepreneur
+- **Minimal Setup** – avoid complex local environment configuration.  
+  Important for: Vibe Coder Entrepreneur
+- **Creative Flexibility** – support unconventional or multimodal features.  
+  Important for: Vibe Coder Entrepreneur

--- a/user_persona_recommendations/professional_researcher/profile.md
+++ b/user_persona_recommendations/professional_researcher/profile.md
@@ -2,8 +2,19 @@
 
 Researchers who write papers, analyze literature, and prototype algorithms across domains.
 
+### Key Criteria
+- **Literature Coverage** – access to broad and credible academic sources.
+- **Experiment Orchestration** – coordinate multiple models and datasets.
+- **Code Reusability** – find and adapt existing research code.
+
 ## Recommended Tools
 - **Perplexity_Labs** – comprehensive search over academic sources.
 - **ChatGPT_agent** – summarize papers and draft sections.
 - **LangGraph** – orchestrate experiments involving multiple models and tools.
 - **Sourcegraph_Cody** – explore and reuse research code repositories.
+
+## Why These Tools
+- **Perplexity_Labs** yields targeted academic references.
+- **ChatGPT_agent** speeds up literature digestion and writing.
+- **LangGraph** links datasets, models, and evaluation steps.
+- **Sourcegraph_Cody** uncovers reusable code across repositories.

--- a/user_persona_recommendations/self_employed_consultant/profile.md
+++ b/user_persona_recommendations/self_employed_consultant/profile.md
@@ -2,8 +2,19 @@
 
 Independent professionals who automate workflows to serve more clients efficiently.
 
+### Key Criteria
+- **Automation Efficiency** – deliver results with minimal manual work.
+- **Client Customization** – adapt tools to varied client requirements.
+- **Reliability** – produce maintainable solutions that can run unattended.
+
 ## Recommended Tools
 - **LangGraph** – design reusable automation pipelines.
-- **OpenAI_Codex** – generate scripts that integrate with existing tools.
+- **OpenAI_GPT4o** – generate scripts that integrate with existing tools.
 - **Cursor** – maintain client-specific codebases with AI assistance.
 - **SWE-agent** – plan and execute multi-step coding tasks on behalf of clients.
+
+## Why These Tools
+- **LangGraph** structures reusable workflows for many clients.
+- **OpenAI_GPT4o** produces adaptable scripts from natural language.
+- **Cursor** streamlines edits across diverse projects.
+- **SWE-agent** automates complex implementations end to end.

--- a/user_persona_recommendations/software_engineer_traditional_ide/profile.md
+++ b/user_persona_recommendations/software_engineer_traditional_ide/profile.md
@@ -2,8 +2,19 @@
 
 Engineers accustomed to Visual Studio, IntelliJ, or similar IDEs who want AI assistance without leaving familiar workflows.
 
+### Key Criteria
+- **IDE Integration** – seamless operation as plugins inside existing editors.
+- **Code Quality Assurance** – suggestions that improve readability and safety.
+- **Cloud Tooling Alignment** – support for cloud providers and enterprise stacks.
+
 ## Recommended Tools
 - **GitHub_Copilot** – inline code suggestions directly in major IDEs.
 - **Sourcegraph_Cody** – deep code understanding and navigation across large codebases.
-- **Cursor** – an AI-first editor that keeps IDE features while enhancing AI-powered refactoring.
+- **Codeium** – AI completions with broad IDE plugin support.
 - **Amazon_CodeWhisperer** – integrates with AWS tooling for cloud-centric projects.
+
+## Why These Tools
+- **GitHub_Copilot** fits smoothly into popular IDEs.
+- **Sourcegraph_Cody** accelerates comprehension of vast codebases.
+- **Codeium** supplies fast, privacy-friendly suggestions in many editors.
+- **Amazon_CodeWhisperer** links code hints to AWS services for deployment.

--- a/user_persona_recommendations/vibe_coder_entrepreneur/profile.md
+++ b/user_persona_recommendations/vibe_coder_entrepreneur/profile.md
@@ -2,8 +2,19 @@
 
 Non-traditional coders building applications to support a business idea with minimal formal training.
 
+### Key Criteria
+- **Rapid Prototyping** – move from idea to demo quickly.
+- **Minimal Setup** – avoid complex local environments.
+- **Creative Flexibility** – support unconventional or multimodal features.
+
 ## Recommended Tools
 - **Cursor** – intuitive AI coding environment that emphasizes usability.
 - **Claude_Code** – natural language code generation for rapid prototyping.
 - **Replit_AI** – deploy full-stack apps without heavy setup.
 - **Gemini_CLI** – experiment with multimodal inputs for creative features.
+
+## Why These Tools
+- **Cursor** keeps the focus on ideas with built-in AI guidance.
+- **Claude_Code** translates ambitions into functional code snippets.
+- **Replit_AI** hosts and deploys demos instantly.
+- **Gemini_CLI** opens novel interactions with images or audio.


### PR DESCRIPTION
## Summary
- add key criteria and reasoning sections to all persona profiles
- refine tool selections for business, consultant, and IDE personas
- collect unified criteria definitions in `persona_crieria.md`

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895dab456d0832191a759966b9b7548