### PR TITLE
Add draft outlining additional AI agent personas

### DIFF
--- a/user_persona_recommendations/additional_personas_draft.md
+++ b/user_persona_recommendations/additional_personas_draft.md
@@ -1,0 +1,44 @@
+# Additional Persona Definitions (Draft)
+
+The current set of personas addresses many segments. To expand coverage and minimize overlaps, the following personas could be added:
+
+## DevOps Automation Engineer
+Operators focused on infrastructure, CI/CD pipelines, and cloud management who rely on AI tools to automate scripts and manage environments.
+### Recommended Tools
+- **Warp** – AI-assisted terminal for efficient command-line workflows.
+- **LogiQCLI** – generate and explain infrastructure scripts on demand.
+- **Amazon_CodeWhisperer** – cloud-centric code suggestions for infrastructure as code.
+- **OpenHands** – run autonomous maintenance tasks across environments.
+
+## QA Test Specialist
+Quality engineers dedicated to test creation, bug detection, and code review.
+### Recommended Tools
+- **Amazon_CodeGuru** – automated code review with performance insights.
+- **DeepCode_AI** – identify vulnerabilities and anti-patterns.
+- **Goose** – propose fixes for failing tests and bugs.
+- **SWE-agent** – execute multi-step debugging plans.
+
+## AI Application Engineer
+Developers integrating and orchestrating AI capabilities into user-facing products.
+### Recommended Tools
+- **LangChain** – compose LLM-powered workflows.
+- **LangGraph** – manage complex multi-agent interactions.
+- **CrewAI** – coordinate specialized agents for feature development.
+- **Qwen_CLI** – experiment with high-quality local models.
+
+## No-Code App Builder
+Entrepreneurs or domain experts assembling full applications through low-code interfaces rather than traditional coding.
+### Recommended Tools
+- **Replit_AI** – build and deploy apps from a browser.
+- **CodeWP** – generate web components and integrations.
+- **ChatGPT_agent** – translate requirements into working modules.
+- **Gemini_CLI** – add multimodal elements without heavy setup.
+
+## Creative Designer Technologist
+Designers and artists exploring interactive or multimedia experiences with the help of AI.
+### Recommended Tools
+- **Gemini_CLI** – experiment with text, image, and audio generation.
+- **Claude_Code** – ideate and scaffold creative code snippets.
+- **z.ai** – brainstorm and refine narratives or copy.
+- **Replit_AI** – prototype interactive concepts quickly.
+


### PR DESCRIPTION
## Summary
- add draft document with potential personas to broaden coverage of AI agent user base

## Testing
- `npm test` *(fails: package.json not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895db5c349c8321afb51fda849e6b0e