### PR TITLE
Add persona docs for emerging developer roles

### DIFF
--- a/user_persona_recommendations/ai_application_engineer/profile.md
+++ b/user_persona_recommendations/ai_application_engineer/profile.md
@@ -1,0 +1,20 @@
+# AI Application Engineer
+
+Developers integrating and orchestrating AI capabilities into user-facing products.
+
+### Key Criteria
+- **Workflow Composition** – build complex AI pipelines from modular components.
+- **Multi-Agent Coordination** – manage interactions between specialized agents.
+- **Model Flexibility** – experiment with diverse local or hosted models.
+
+## Recommended Tools
+- **LangChain** – compose LLM-powered workflows.
+- **LangGraph** – manage complex multi-agent interactions.
+- **CrewAI** – coordinate specialized agents for feature development.
+- **Qwen_CLI** – experiment with high-quality local models.
+
+## Why These Tools
+- **LangChain** orchestrates modular steps in AI applications.
+- **LangGraph** handles dependencies across interacting agents.
+- **CrewAI** synchronizes specialized agents to deliver features.
+- **Qwen_CLI** enables quick testing of advanced local models.

--- a/user_persona_recommendations/creative_designer_technologist/profile.md
+++ b/user_persona_recommendations/creative_designer_technologist/profile.md
@@ -1,0 +1,20 @@
+# Creative Designer Technologist
+
+Designers and artists exploring interactive or multimedia experiences with the help of AI.
+
+### Key Criteria
+- **Multimodal Support** – generate or mix text, image, and audio assets.
+- **Rapid Prototyping** – quickly iterate on interactive concepts.
+- **Creative Coding Guidance** – ideate and scaffold unconventional code snippets.
+
+## Recommended Tools
+- **Gemini_CLI** – experiment with text, image, and audio generation.
+- **Claude_Code** – ideate and scaffold creative code snippets.
+- **z.ai** – brainstorm and refine narratives or copy.
+- **Replit_AI** – prototype interactive concepts quickly.
+
+## Why These Tools
+- **Gemini_CLI** enables multimodal experimentation across media types.
+- **Claude_Code** assists in crafting imaginative code structures.
+- **z.ai** supports brainstorming and narrative refinement.
+- **Replit_AI** allows fast prototyping of interactive ideas.

--- a/user_persona_recommendations/devops_automation_engineer/profile.md
+++ b/user_persona_recommendations/devops_automation_engineer/profile.md
@@ -1,0 +1,20 @@
+# DevOps Automation Engineer
+
+Operators focused on infrastructure, CI/CD pipelines, and cloud management who rely on AI tools to automate scripts and manage environments.
+
+### Key Criteria
+- **Infrastructure Orchestration** – automate provisioning and configuration across environments.
+- **CI/CD Integration** – hook into continuous integration and deployment pipelines.
+- **Cloud Environment Management** – manage multi-cloud resources and permissions.
+
+## Recommended Tools
+- **Warp** – AI-assisted terminal for efficient command-line workflows.
+- **LogiQCLI** – generate and explain infrastructure scripts on demand.
+- **Amazon_CodeWhisperer** – cloud-centric code suggestions for infrastructure as code.
+- **OpenHands** – run autonomous maintenance tasks across environments.
+
+## Why These Tools
+- **Warp** accelerates terminal workflows with command suggestions and reusable templates.
+- **LogiQCLI** produces infrastructure scripts with clear explanations.
+- **Amazon_CodeWhisperer** offers cloud-aware autocompletion for IaC tasks.
+- **OpenHands** can autonomously execute maintenance and deployment operations.

--- a/user_persona_recommendations/no_code_app_builder/profile.md
+++ b/user_persona_recommendations/no_code_app_builder/profile.md
@@ -1,0 +1,20 @@
+# No-Code App Builder
+
+Entrepreneurs or domain experts assembling full applications through low-code interfaces rather than traditional coding.
+
+### Key Criteria
+- **Visual Development** – build apps using drag-and-drop or form-based interfaces.
+- **Component Templates** – access libraries of pre-built modules and integrations.
+- **One-Click Deployment** – publish apps without managing infrastructure.
+
+## Recommended Tools
+- **Replit_AI** – build and deploy apps from a browser.
+- **CodeWP** – generate web components and integrations.
+- **ChatGPT_agent** – translate requirements into working modules.
+- **Gemini_CLI** – add multimodal elements without heavy setup.
+
+## Why These Tools
+- **Replit_AI** enables browser-based development and deployment.
+- **CodeWP** provides templates that assemble web components quickly.
+- **ChatGPT_agent** converts natural language into functional modules.
+- **Gemini_CLI** adds multimodal features with minimal configuration.

--- a/user_persona_recommendations/persona_crieria.md
+++ b/user_persona_recommendations/persona_crieria.md
@@ -48,3 +48,33 @@
   Important for: Vibe Coder Entrepreneur
 - **Creative Flexibility** – support unconventional or multimodal features.  
   Important for: Vibe Coder Entrepreneur
+- **Infrastructure Orchestration** – automate provisioning and configuration across environments.
+  Important for: DevOps Automation Engineer
+- **CI/CD Integration** – connect seamlessly with continuous integration and deployment pipelines.
+  Important for: DevOps Automation Engineer
+- **Cloud Environment Management** – manage multi-cloud resources and permissions.
+  Important for: DevOps Automation Engineer
+- **Automated Test Generation** – create unit and integration tests automatically.
+  Important for: QA Test Specialist
+- **Bug Detection** – surface vulnerabilities and code smells early.
+  Important for: QA Test Specialist
+- **Debugging Support** – propose fixes and guide troubleshooting.
+  Important for: QA Test Specialist
+- **Workflow Composition** – build complex AI pipelines from modular components.
+  Important for: AI Application Engineer
+- **Multi-Agent Coordination** – manage interactions among specialized agents.
+  Important for: AI Application Engineer
+- **Model Flexibility** – experiment with diverse local or hosted models.
+  Important for: AI Application Engineer
+- **Visual Development** – enable drag-and-drop or form-based app creation.
+  Important for: No-Code App Builder
+- **Component Templates** – offer libraries of pre-built modules and integrations.
+  Important for: No-Code App Builder
+- **One-Click Deployment** – publish applications without managing infrastructure.
+  Important for: No-Code App Builder
+- **Multimodal Support** – generate or mix text, image, and audio assets.
+  Important for: Creative Designer Technologist
+- **Rapid Prototyping** – quickly iterate on interactive concepts.
+  Important for: Creative Designer Technologist
+- **Creative Coding Guidance** – scaffold unconventional or artistic code.
+  Important for: Creative Designer Technologist

--- a/user_persona_recommendations/qa_test_specialist/profile.md
+++ b/user_persona_recommendations/qa_test_specialist/profile.md
@@ -1,0 +1,20 @@
+# QA Test Specialist
+
+Quality engineers dedicated to test creation, bug detection, and code review.
+
+### Key Criteria
+- **Automated Test Generation** – create unit and integration tests from code or specs.
+- **Bug Detection** – highlight vulnerabilities and anti-patterns before release.
+- **Debugging Support** – propose fixes and guide troubleshooting.
+
+## Recommended Tools
+- **Amazon_CodeGuru** – automated code review with performance insights.
+- **DeepCode_AI** – identify vulnerabilities and anti-patterns.
+- **Goose** – propose fixes for failing tests and bugs.
+- **SWE-agent** – execute multi-step debugging plans.
+
+## Why These Tools
+- **Amazon_CodeGuru** automates code review and offers performance feedback.
+- **DeepCode_AI** surfaces security issues and code smells.
+- **Goose** suggests actionable fixes for failing tests.
+- **SWE-agent** carries out structured debugging sequences.


### PR DESCRIPTION
## Summary
- add profiles for DevOps Automation Engineer, QA Test Specialist, AI Application Engineer, No-Code App Builder, and Creative Designer Technologist
- expand persona criteria with requirements for these new roles

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895e53ca9488321a53acddd05b2b306