### PR TITLE
Add Aider agent profile and persona recommendations

### DIFF
--- a/agents.json
+++ b/agents.json
@@ -27,7 +27,7 @@
       "benchmarks": {
         "swe_bench_score": 49,
         "swe_bench_source": "https://www.anthropic.com/research/swe-bench-sonnet",
-        "terminal_bench_score": "43.2% ± 1.3",
+        "terminal_bench_score": "43.2% \u00b1 1.3",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard",
         "task_success_rate": 0.432,
         "resource_usage": "Not publicly documented"
@@ -57,7 +57,7 @@
       ],
       "pricing_model": "Requires an OpenAI API key or a paid OpenAI account (Plus/Pro).",
       "benchmarks": {
-        "terminal_bench_score": "20.0% ± 1.5",
+        "terminal_bench_score": "20.0% \u00b1 1.5",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard",
         "task_success_rate": 0.2,
         "resource_usage": "Runs locally; resource usage depends on chosen model"
@@ -111,7 +111,7 @@
       ],
       "pricing_model": "Open-source",
       "benchmarks": {
-        "terminal_bench_score": "42.0% ± 1.3",
+        "terminal_bench_score": "42.0% \u00b1 1.3",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard",
         "task_success_rate": 0.42,
         "resource_usage": "Depends on local hardware and model; no public metrics"
@@ -230,6 +230,34 @@
         "ease_of_use": 2,
         "documentation_quality": 2,
         "onboarding_experience": 2
+      }
+    },
+    {
+      "name": "Aider",
+      "website": "https://aider.chat/",
+      "developer": "Paul Gauthier",
+      "key_features": [
+        "Chat-based pair programming in the terminal",
+        "Deep Git integration with automatic commits",
+        "Edits multiple files with model-generated patches",
+        "Runs tests and applies fixes iteratively"
+      ],
+      "supported_models": [
+        "OpenAI GPT-4 family",
+        "Anthropic Claude 3 models",
+        "Google Gemini models",
+        "Local models via OpenRouter or Ollama"
+      ],
+      "pricing_model": "Open-source; users pay for underlying model API usage",
+      "benchmarks": {
+        "swe_bench_score": null,
+        "task_success_rate": null,
+        "resource_usage": ""
+      },
+      "qualitative_assessment": {
+        "ease_of_use": null,
+        "documentation_quality": null,
+        "onboarding_experience": null
       }
     }
   ],
@@ -1108,7 +1136,7 @@
       ],
       "pricing_model": "Cloud-based platform with a free tier and enterprise options.",
       "benchmarks": {
-        "terminal_bench_score": "42.5% ± 0.8",
+        "terminal_bench_score": "42.5% \u00b1 0.8",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard"
       },
       "qualitative_assessment": {
@@ -1158,7 +1186,7 @@
       ],
       "pricing_model": "Open-source under the MIT License; free for self-hosting with optional paid hosting via Daytona",
       "benchmarks": {
-        "terminal_bench_score": "41.3% ± 0.7",
+        "terminal_bench_score": "41.3% \u00b1 0.7",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard",
         "task_success_rate": 0.413,
         "resource_usage": "Not publicly documented; depends on hosting environment and model"
@@ -1218,7 +1246,7 @@
       ],
       "pricing_model": "Research project, likely free to use.",
       "benchmarks": {
-        "terminal_bench_score": "39.9% ± 1.0",
+        "terminal_bench_score": "39.9% \u00b1 1.0",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard",
         "task_success_rate": 0.399,
         "resource_usage": "Not publicly documented; depends on remote environment and model"

--- a/agents/Aider/profile.md
+++ b/agents/Aider/profile.md
@@ -1,0 +1,37 @@
+# Aider
+
+## Overview
+
+Aider is an open-source command-line pair programming tool that uses large language models to edit your codebase.
+
+## Key Information
+
+- **Developer:** Paul Gauthier
+- **Website:** [https://aider.chat/](https://aider.chat/)
+- **Pricing:** Open-source; usage based on model APIs
+
+## Key Features
+
+- **Chat-based workflow:** Applies model suggestions as Git patches across multiple files.
+- **Test-driven fixes:** Runs unit tests and iteratively applies corrections.
+- **Terminal-focused:** Works entirely from the command line with minimal setup.
+- **Automatic commits:** Generates commit messages and tracks changes in version control.
+
+## Supported Models
+
+- OpenAI GPT-4 family
+- Anthropic Claude 3 models
+- Google Gemini models
+- Local models via OpenRouter or Ollama
+
+## Benchmarks
+
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+
+- **Ease of Use:** Not available
+- **Documentation Quality:** Not available
+- **Onboarding Experience:** Not available

--- a/persona_recommendations/persona_recommendations.json
+++ b/persona_recommendations/persona_recommendations.json
@@ -1,0 +1,7 @@
+{
+  "Aider": [
+    "ai_application_engineer",
+    "self_employed_consultant",
+    "professional_researcher"
+  ]
+}


### PR DESCRIPTION
## Summary
- add Aider terminal coding assistant to `agents.json`
- document Aider features and model support in `agents/Aider/profile.md`
- record recommended personas for Aider in `persona_recommendations.json`

## Testing
- `jq '.' agents.json`
- `jq '.' persona_recommendations/persona_recommendations.json`
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896197ed310832195560e8bf72eb004