### PR TITLE
Align persona folders with persona criteria

### DIFF
--- a/persona_recommendations/beginner_student_creator/profile.md
+++ b/persona_recommendations/beginner_student_creator/profile.md
@@ -4,7 +4,6 @@ Students and hobbyists starting their coding journey and eager to learn through 
 
 ### Key Criteria
 - **Beginner-Friendly Onboarding** – simple setup, guidance, and affordability.
-- **Visual/No-Code Development** – drag-and-drop or template-driven prototyping.
 - **Creative Multimodal Exploration** – experiment with text, image, or audio outputs.
 
 ## Recommended Tools

--- a/persona_recommendations/business_user_automation_seeker/profile.md
+++ b/persona_recommendations/business_user_automation_seeker/profile.md
@@ -5,7 +5,7 @@ Sales, presales, and management professionals who need to automate reports, pres
 ### Key Criteria
 - **Visual/No-Code Development** – build workflows using drag-and-drop components.
 - **Automation & Productivity** – reduce manual work and repetitive tasks.
-- **Data & Experimental Flexibility** – connect to spreadsheets, CRMs, or other data sources.
+- **Beginner-Friendly Onboarding** – simple setup, guidance, and affordability.
 
 ## Recommended Tools
 - **ChatGPT_agent** – draft presentations and automate document formatting.

--- a/persona_recommendations/creative_designer_technologist/profile.md
+++ b/persona_recommendations/creative_designer_technologist/profile.md
@@ -5,7 +5,6 @@ Designers and artists exploring interactive or multimedia experiences with the h
 ### Key Criteria
 - **Creative Multimodal Exploration** – mix text, image, and audio assets.
 - **Visual/No-Code Development** – prototype quickly with templates.
-- **Data & Experimental Flexibility** – adapt models and data for creative projects.
 
 ## Recommended Tools
 - **Gemini_CLI** – experiment with text, image, and audio generation.

--- a/persona_recommendations/data_scientist/profile.md
+++ b/persona_recommendations/data_scientist/profile.md
@@ -4,8 +4,6 @@ Practitioners focused on data pipelines, modeling, and analysis who want AI assi
 
 ### Key Criteria
 - **Data & Experimental Flexibility** – integrate with pipelines and ensure reproducibility.
-- **Workflow & Agent Orchestration** – coordinate models and tools in experiments.
-- **Automation & Productivity** – reduce manual overhead in data processes.
 
 ## Recommended Tools
 - **LangChain** – build data-aware applications with complex toolchains.

--- a/persona_recommendations/no_code_app_builder/profile.md
+++ b/persona_recommendations/no_code_app_builder/profile.md
@@ -5,7 +5,6 @@ Entrepreneurs or domain experts assembling full applications through low-code in
 ### Key Criteria
 - **Beginner-Friendly Onboarding** – start building with minimal setup.
 - **Visual/No-Code Development** – drag-and-drop or template-based creation.
-- **Automation & Productivity** – quickly assemble workflows and deploy.
 
 ## Recommended Tools
 - **Replit_AI** – build and deploy apps from a browser.

--- a/persona_recommendations/professional_researcher/profile.md
+++ b/persona_recommendations/professional_researcher/profile.md
@@ -5,7 +5,6 @@ Researchers who write papers, analyze literature, and prototype algorithms acros
 ### Key Criteria
 - **Data & Experimental Flexibility** – manage datasets, models, and reproducible experiments.
 - **Workflow & Agent Orchestration** – coordinate multi-step research pipelines.
-- **Codebase Comprehension** – find and reuse existing research code.
 
 ## Recommended Tools
 - **Perplexity_Labs** – comprehensive search over academic sources.

--- a/persona_recommendations/returning_engineering_manager/profile.md
+++ b/persona_recommendations/returning_engineering_manager/profile.md
@@ -4,8 +4,6 @@ A manager who stepped away from daily coding and wants to regain hands-on experi
 
 ### Key Criteria
 - **Codebase Comprehension** – regain context across large or unfamiliar projects.
-- **Automation & Productivity** – leverage AI to ramp up efficiency quickly.
-- **Code Quality & Testing** – evaluate reliability and design trade-offs.
 
 ## Recommended Tools
 - **GitHub_Copilot** – quickly recall syntax and patterns with inline guidance.

--- a/persona_recommendations/self_employed_consultant/profile.md
+++ b/persona_recommendations/self_employed_consultant/profile.md
@@ -6,6 +6,7 @@ Independent professionals who automate workflows to serve more clients efficient
 - **Automation & Productivity** – deliver results with minimal manual work.
 - **Workflow & Agent Orchestration** – assemble reusable automation pipelines.
 - **Data & Experimental Flexibility** – adapt to varied client data environments.
+- **Code Quality & Testing** – ensure reliable, maintainable implementations.
 
 ## Recommended Tools
 - **LangGraph** – design reusable automation pipelines.

--- a/persona_recommendations/traditional_ide_software_engineer/profile.md
+++ b/persona_recommendations/traditional_ide_software_engineer/profile.md
@@ -5,7 +5,6 @@ Engineers accustomed to Visual Studio, IntelliJ, or similar IDEs who want AI ass
 ### Key Criteria
 - **Codebase Comprehension** – understand large projects within familiar IDEs.
 - **Code Quality & Testing** – improve reliability and safety.
-- **Automation & Productivity** – streamline coding inside existing workflows.
 
 ## Recommended Tools
 - **GitHub_Copilot** – inline code suggestions directly in major IDEs.


### PR DESCRIPTION
## Summary
- Rename persona directories to match identifiers in `persona_criteria.json`
- Update each persona profile's key criteria to reflect the associated criteria
- Add missing Code Quality & Testing criterion for self-employed consultant

## Testing
- `npm test` *(fails: no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ba4e22ed48321a95d9b11c2e53e6b