### PR TITLE
Align persona ratings to new criteria and split per agent

### DIFF
--- a/agents/Amazon_CodeGuru/persona_ratings_amazon_codeguru.json
+++ b/agents/Amazon_CodeGuru/persona_ratings_amazon_codeguru.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Amazon_CodeWhisperer/persona_ratings_amazon_codewhisperer.json
+++ b/agents/Amazon_CodeWhisperer/persona_ratings_amazon_codewhisperer.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Android_Studio_Bot/persona_ratings_android_studio_bot.json
+++ b/agents/Android_Studio_Bot/persona_ratings_android_studio_bot.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/AskCodi/persona_ratings_askcodi.json
+++ b/agents/AskCodi/persona_ratings_askcodi.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/ChatGPT_agent/persona_ratings_chatgpt_agent.json
+++ b/agents/ChatGPT_agent/persona_ratings_chatgpt_agent.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Claude_Code/persona_ratings_claude_code.json
+++ b/agents/Claude_Code/persona_ratings_claude_code.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Cline/persona_ratings_cline.json
+++ b/agents/Cline/persona_ratings_cline.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/CodeGPT/persona_ratings_codegpt.json
+++ b/agents/CodeGPT/persona_ratings_codegpt.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/CodeWP/persona_ratings_codewp.json
+++ b/agents/CodeWP/persona_ratings_codewp.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Codex_CLI/persona_ratings_codex_cli.json
+++ b/agents/Codex_CLI/persona_ratings_codex_cli.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/CrewAI/persona_ratings_crewai.json
+++ b/agents/CrewAI/persona_ratings_crewai.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Cursor/persona_ratings_cursor.json
+++ b/agents/Cursor/persona_ratings_cursor.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/DeepCode_AI/persona_ratings_deepcode_ai.json
+++ b/agents/DeepCode_AI/persona_ratings_deepcode_ai.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Engine/persona_ratings_engine.json
+++ b/agents/Engine/persona_ratings_engine.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Gemini_CLI/persona_ratings_gemini_cli.json
+++ b/agents/Gemini_CLI/persona_ratings_gemini_cli.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/GitHub_Copilot/persona_ratings_github_copilot.json
+++ b/agents/GitHub_Copilot/persona_ratings_github_copilot.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Goose/persona_ratings_goose.json
+++ b/agents/Goose/persona_ratings_goose.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Jules/persona_ratings_jules.json
+++ b/agents/Jules/persona_ratings_jules.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Kilo/persona_ratings_kilo.json
+++ b/agents/Kilo/persona_ratings_kilo.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/LangChain/persona_ratings_langchain.json
+++ b/agents/LangChain/persona_ratings_langchain.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/LangGraph/persona_ratings_langgraph.json
+++ b/agents/LangGraph/persona_ratings_langgraph.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Letta/persona_ratings_letta.json
+++ b/agents/Letta/persona_ratings_letta.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/LogiQCLI/persona_ratings_logiqcli.json
+++ b/agents/LogiQCLI/persona_ratings_logiqcli.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Minimax_agent/persona_ratings_minimax_agent.json
+++ b/agents/Minimax_agent/persona_ratings_minimax_agent.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/OpenAI_Codex/persona_ratings_openai_codex.json
+++ b/agents/OpenAI_Codex/persona_ratings_openai_codex.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/OpenHands/persona_ratings_openhands.json
+++ b/agents/OpenHands/persona_ratings_openhands.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Perplexity_Labs/persona_ratings_perplexity_labs.json
+++ b/agents/Perplexity_Labs/persona_ratings_perplexity_labs.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Qwen_CLI/persona_ratings_qwen_cli.json
+++ b/agents/Qwen_CLI/persona_ratings_qwen_cli.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Replit_AI/persona_ratings_replit_ai.json
+++ b/agents/Replit_AI/persona_ratings_replit_ai.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Roo_Code/persona_ratings_roo_code.json
+++ b/agents/Roo_Code/persona_ratings_roo_code.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/SQLAI/persona_ratings_sqlai.json
+++ b/agents/SQLAI/persona_ratings_sqlai.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/SWE-agent/persona_ratings_swe-agent.json
+++ b/agents/SWE-agent/persona_ratings_swe-agent.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Sourcegraph_Cody/persona_ratings_sourcegraph_cody.json
+++ b/agents/Sourcegraph_Cody/persona_ratings_sourcegraph_cody.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Tabnine/persona_ratings_tabnine.json
+++ b/agents/Tabnine/persona_ratings_tabnine.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Terminus/persona_ratings_terminus.json
+++ b/agents/Terminus/persona_ratings_terminus.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Trae/persona_ratings_trae.json
+++ b/agents/Trae/persona_ratings_trae.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/Warp/persona_ratings_warp.json
+++ b/agents/Warp/persona_ratings_warp.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/chat.z.ai/persona_ratings_chat.z.ai.json
+++ b/agents/chat.z.ai/persona_ratings_chat.z.ai.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/devin/persona_ratings_devin.json
+++ b/agents/devin/persona_ratings_devin.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/manus/persona_ratings_manus.json
+++ b/agents/manus/persona_ratings_manus.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/mini-SWE-agent/persona_ratings_mini-swe-agent.json
+++ b/agents/mini-SWE-agent/persona_ratings_mini-swe-agent.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/agents/z.ai/persona_ratings_z.ai.json
+++ b/agents/z.ai/persona_ratings_z.ai.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Research to be done."
+  }
+}

--- a/persona_recommendations/persona_ratings.json
+++ b/persona_recommendations/persona_ratings.json
@@ -1,6468 +1,1428 @@
 {
-  "Claude Code": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "Codex CLI": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "Gemini CLI": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "Goose": {
-    "ease_of_use": {
-      "rating": 2,
-      "reasoning": "Steeper learning curve or setup challenges."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "LogiQCLI": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "Qwen CLI": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 4,
-      "reasoning": "Above average based on positive indications."
-    },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "Warp": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "OpenAI Codex": {
-    "ease_of_use": {
-      "rating": 2,
-      "reasoning": "Steeper learning curve or setup challenges."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
   "Amazon CodeGuru": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 4,
-      "reasoning": "Above average based on positive indications."
-    },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "business_data_integration": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
   "Amazon CodeWhisperer": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "business_data_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
   "Android Studio Bot": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "business_data_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
   "AskCodi": {
-    "ease_of_use": {
+    "automation_productivity": {
       "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "Cline": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "CodeGPT": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "CodeWP": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "Cursor": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 4,
-      "reasoning": "Above average based on positive indications."
-    },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "DeepCode AI": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "GitHub Copilot": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "Kilo": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "Replit AI": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 4,
-      "reasoning": "Above average based on positive indications."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 4,
-      "reasoning": "Above average based on positive indications."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "Roo Code": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 4,
-      "reasoning": "Above average based on positive indications."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 4,
-      "reasoning": "Above average based on positive indications."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "Sourcegraph Cody": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "SQLAI.ai": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "Tabnine": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
       "reasoning": "Research to be done."
     },
-    "multi_agent_coordination": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "model_flexibility": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "visual_development": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "component_templates": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "one_click_deployment": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "multimodal_support": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
   "ChatGPT agent": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 4,
-      "reasoning": "Above average based on positive indications."
-    },
-    "business_data_integration": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 4,
-      "reasoning": "Above average based on positive indications."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
-  "devin": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
+  "Claude Code": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "business_data_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
-  "Engine": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
+  "Cline": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "business_data_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
-  "Jules": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
+  "CodeGPT": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "business_data_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
-  "manus": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
+  "CodeWP": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "business_data_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
-  "Minimax agent": {
-    "ease_of_use": {
+  "Codex CLI": {
+    "automation_productivity": {
       "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "Trae": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 3,
-      "reasoning": "Pricing unclear; treated as average affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 4,
-      "reasoning": "Above average based on positive indications."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "z.ai": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "chat.z.ai": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    }
-  },
-  "Perplexity": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "business_data_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "productivity_gains": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "data_pipeline_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reproducibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "scalability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
       "reasoning": "Research to be done."
     },
-    "multi_agent_coordination": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "model_flexibility": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "visual_development": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "component_templates": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "one_click_deployment": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "multimodal_support": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
   "CrewAI": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "business_data_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "Cursor": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "codebase_navigation": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "architectural_insight": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "literature_coverage": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "experiment_orchestration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "code_reusability": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "automation_efficiency": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "client_customization": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "DeepCode AI": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reliability": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "ide_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "code_quality_assurance": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "cloud_tooling_alignment": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "rapid_prototyping": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "minimal_setup": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "creative_flexibility": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "Engine": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "infrastructure_orchestration": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "ci_cd_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "cloud_environment_management": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "automated_test_generation": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "bug_detection": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "debugging_support": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "workflow_composition": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "Gemini CLI": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "multi_agent_coordination": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "model_flexibility": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "visual_development": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "component_templates": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "one_click_deployment": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "multimodal_support": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "GitHub Copilot": {
+    "automation_productivity": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "beginner_friendly_onboarding": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "code_quality_testing": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "codebase_comprehension": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "creative_multimodal_exploration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "data_experimental_flexibility": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "visual_no_code_development": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "Goose": {
+    "automation_productivity": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "beginner_friendly_onboarding": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "code_quality_testing": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "codebase_comprehension": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "creative_multimodal_exploration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "data_experimental_flexibility": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "visual_no_code_development": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "Jules": {
+    "automation_productivity": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "beginner_friendly_onboarding": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "code_quality_testing": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "codebase_comprehension": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "creative_multimodal_exploration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "data_experimental_flexibility": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "visual_no_code_development": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "Kilo": {
+    "automation_productivity": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "beginner_friendly_onboarding": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "code_quality_testing": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "codebase_comprehension": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "creative_multimodal_exploration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "data_experimental_flexibility": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "visual_no_code_development": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
   "LangChain": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "business_data_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
   "LangGraph": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "business_data_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
   "Letta": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
-      "rating": 4,
-      "reasoning": "Above average based on positive indications."
-    },
-    "business_data_integration": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "codebase_navigation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "architectural_insight": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "literature_coverage": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "experiment_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_reusability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automation_efficiency": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "client_customization": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "reliability": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ide_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "code_quality_assurance": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_tooling_alignment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "rapid_prototyping": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "minimal_setup": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 4,
-      "reasoning": "Above average based on positive indications."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
-  "mini-SWE-agent": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
+  "LogiQCLI": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "business_data_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "Minimax agent": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "codebase_navigation": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "architectural_insight": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "literature_coverage": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "experiment_orchestration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "code_reusability": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "automation_efficiency": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "client_customization": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "OpenAI Codex": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reliability": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "ide_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "code_quality_assurance": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "cloud_tooling_alignment": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "rapid_prototyping": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "minimal_setup": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
   "OpenHands": {
-    "ease_of_use": {
-      "rating": 2,
-      "reasoning": "Steeper learning curve or setup challenges."
-    },
-    "guided_learning": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "business_data_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "Perplexity": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "codebase_navigation": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "architectural_insight": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "literature_coverage": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "experiment_orchestration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "code_reusability": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "automation_efficiency": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "client_customization": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "Qwen CLI": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reliability": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "ide_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "code_quality_assurance": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "cloud_tooling_alignment": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "rapid_prototyping": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "minimal_setup": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "creative_flexibility": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "Replit AI": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "infrastructure_orchestration": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "ci_cd_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "cloud_environment_management": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "automated_test_generation": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "bug_detection": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "debugging_support": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "workflow_composition": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "Roo Code": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "multi_agent_coordination": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "model_flexibility": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "visual_development": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "component_templates": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "one_click_deployment": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "multimodal_support": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "SQLAI.ai": {
+    "automation_productivity": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "beginner_friendly_onboarding": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "code_quality_testing": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "codebase_comprehension": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "creative_multimodal_exploration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "data_experimental_flexibility": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "visual_no_code_development": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
   "SWE-agent": {
-    "ease_of_use": {
-      "rating": 3,
-      "reasoning": "Standard usability with no major hurdles noted."
-    },
-    "guided_learning": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "business_data_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "Sourcegraph Cody": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "codebase_navigation": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "architectural_insight": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "literature_coverage": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "experiment_orchestration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "code_reusability": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "automation_efficiency": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "client_customization": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "Tabnine": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reliability": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "ide_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "code_quality_assurance": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "cloud_tooling_alignment": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "rapid_prototyping": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "minimal_setup": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "creative_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "infrastructure_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "ci_cd_integration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "cloud_environment_management": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "automated_test_generation": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "bug_detection": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "debugging_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "workflow_composition": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multi_agent_coordination": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "model_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "visual_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "component_templates": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "one_click_deployment": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "multimodal_support": {
-      "rating": 3,
-      "reasoning": "Research to be done."
-    },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }
   },
   "Terminus": {
-    "ease_of_use": {
-      "rating": 1,
-      "reasoning": "Complex interface or setup severely hinders usability."
-    },
-    "guided_learning": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "affordability": {
-      "rating": 5,
-      "reasoning": "Free and open-source, maximizing affordability."
-    },
-    "no_code_accessibility": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "business_data_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "productivity_gains": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "data_pipeline_integration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reproducibility": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "scalability": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "fast_reacclimation": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "Trae": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "codebase_navigation": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "architectural_insight": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "literature_coverage": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "experiment_orchestration": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "code_reusability": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "automation_efficiency": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "client_customization": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "Warp": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "reliability": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "ide_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "code_quality_assurance": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "cloud_tooling_alignment": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "rapid_prototyping": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "minimal_setup": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "creative_flexibility": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "chat.z.ai": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "infrastructure_orchestration": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "ci_cd_integration": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "cloud_environment_management": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "automated_test_generation": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "bug_detection": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "debugging_support": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "workflow_composition": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "devin": {
+    "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "multi_agent_coordination": {
+    "beginner_friendly_onboarding": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "model_flexibility": {
+    "code_quality_testing": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "visual_development": {
+    "codebase_comprehension": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "component_templates": {
+    "creative_multimodal_exploration": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "one_click_deployment": {
+    "data_experimental_flexibility": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "multimodal_support": {
+    "visual_no_code_development": {
       "rating": 3,
       "reasoning": "Research to be done."
     },
-    "creative_coding_guidance": {
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "manus": {
+    "automation_productivity": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "beginner_friendly_onboarding": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "code_quality_testing": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "codebase_comprehension": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "creative_multimodal_exploration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "data_experimental_flexibility": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "visual_no_code_development": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "mini-SWE-agent": {
+    "automation_productivity": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "beginner_friendly_onboarding": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "code_quality_testing": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "codebase_comprehension": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "creative_multimodal_exploration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "data_experimental_flexibility": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "visual_no_code_development": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    }
+  },
+  "z.ai": {
+    "automation_productivity": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "beginner_friendly_onboarding": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "code_quality_testing": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "codebase_comprehension": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "creative_multimodal_exploration": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "data_experimental_flexibility": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "visual_no_code_development": {
+      "rating": 3,
+      "reasoning": "Research to be done."
+    },
+    "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Research to be done."
     }

--- a/persona_recommendations/persona_ratings.schema.json
+++ b/persona_recommendations/persona_ratings.schema.json
@@ -5,160 +5,40 @@
     ".*": {
       "type": "object",
       "properties": {
-        "affordability": {
+        "beginner_friendly_onboarding": {
           "$ref": "#/definitions/rating"
         },
-        "architectural_insight": {
+        "visual_no_code_development": {
           "$ref": "#/definitions/rating"
         },
-        "automated_test_generation": {
+        "automation_productivity": {
           "$ref": "#/definitions/rating"
         },
-        "automation_efficiency": {
+        "data_experimental_flexibility": {
           "$ref": "#/definitions/rating"
         },
-        "bug_detection": {
+        "workflow_agent_orchestration": {
           "$ref": "#/definitions/rating"
         },
-        "business_data_integration": {
+        "codebase_comprehension": {
           "$ref": "#/definitions/rating"
         },
-        "ci_cd_integration": {
+        "code_quality_testing": {
           "$ref": "#/definitions/rating"
         },
-        "client_customization": {
-          "$ref": "#/definitions/rating"
-        },
-        "cloud_environment_management": {
-          "$ref": "#/definitions/rating"
-        },
-        "cloud_tooling_alignment": {
-          "$ref": "#/definitions/rating"
-        },
-        "code_quality_assurance": {
-          "$ref": "#/definitions/rating"
-        },
-        "code_reusability": {
-          "$ref": "#/definitions/rating"
-        },
-        "codebase_navigation": {
-          "$ref": "#/definitions/rating"
-        },
-        "component_templates": {
-          "$ref": "#/definitions/rating"
-        },
-        "creative_coding_guidance": {
-          "$ref": "#/definitions/rating"
-        },
-        "creative_flexibility": {
-          "$ref": "#/definitions/rating"
-        },
-        "data_pipeline_integration": {
-          "$ref": "#/definitions/rating"
-        },
-        "debugging_support": {
-          "$ref": "#/definitions/rating"
-        },
-        "ease_of_use": {
-          "$ref": "#/definitions/rating"
-        },
-        "experiment_orchestration": {
-          "$ref": "#/definitions/rating"
-        },
-        "fast_reacclimation": {
-          "$ref": "#/definitions/rating"
-        },
-        "guided_learning": {
-          "$ref": "#/definitions/rating"
-        },
-        "ide_integration": {
-          "$ref": "#/definitions/rating"
-        },
-        "infrastructure_orchestration": {
-          "$ref": "#/definitions/rating"
-        },
-        "literature_coverage": {
-          "$ref": "#/definitions/rating"
-        },
-        "minimal_setup": {
-          "$ref": "#/definitions/rating"
-        },
-        "model_flexibility": {
-          "$ref": "#/definitions/rating"
-        },
-        "multi_agent_coordination": {
-          "$ref": "#/definitions/rating"
-        },
-        "multimodal_support": {
-          "$ref": "#/definitions/rating"
-        },
-        "no_code_accessibility": {
-          "$ref": "#/definitions/rating"
-        },
-        "one_click_deployment": {
-          "$ref": "#/definitions/rating"
-        },
-        "productivity_gains": {
-          "$ref": "#/definitions/rating"
-        },
-        "rapid_prototyping": {
-          "$ref": "#/definitions/rating"
-        },
-        "reliability": {
-          "$ref": "#/definitions/rating"
-        },
-        "reproducibility": {
-          "$ref": "#/definitions/rating"
-        },
-        "scalability": {
-          "$ref": "#/definitions/rating"
-        },
-        "visual_development": {
-          "$ref": "#/definitions/rating"
-        },
-        "workflow_composition": {
+        "creative_multimodal_exploration": {
           "$ref": "#/definitions/rating"
         }
       },
       "required": [
-        "affordability",
-        "architectural_insight",
-        "automated_test_generation",
-        "automation_efficiency",
-        "bug_detection",
-        "business_data_integration",
-        "ci_cd_integration",
-        "client_customization",
-        "cloud_environment_management",
-        "cloud_tooling_alignment",
-        "code_quality_assurance",
-        "code_reusability",
-        "codebase_navigation",
-        "component_templates",
-        "creative_coding_guidance",
-        "creative_flexibility",
-        "data_pipeline_integration",
-        "debugging_support",
-        "ease_of_use",
-        "experiment_orchestration",
-        "fast_reacclimation",
-        "guided_learning",
-        "ide_integration",
-        "infrastructure_orchestration",
-        "literature_coverage",
-        "minimal_setup",
-        "model_flexibility",
-        "multi_agent_coordination",
-        "multimodal_support",
-        "no_code_accessibility",
-        "one_click_deployment",
-        "productivity_gains",
-        "rapid_prototyping",
-        "reliability",
-        "reproducibility",
-        "scalability",
-        "visual_development",
-        "workflow_composition"
+        "beginner_friendly_onboarding",
+        "visual_no_code_development",
+        "automation_productivity",
+        "data_experimental_flexibility",
+        "workflow_agent_orchestration",
+        "codebase_comprehension",
+        "code_quality_testing",
+        "creative_multimodal_exploration"
       ],
       "additionalProperties": false
     }


### PR DESCRIPTION
## Summary
- update persona ratings schema to use criteria from `persona_criteria.json`
- rebuild consolidated persona ratings with the new criteria
- generate individual rating files for each agent in its directory

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ba64fa8e48321bd873a6271bbe916