### PR TITLE
Add persona ratings for Aider

### DIFF
--- a/agents/Aider/persona_ratings_aider.json
+++ b/agents/Aider/persona_ratings_aider.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 4,
+    "reasoning": "Chat-based CLI applies model suggestions as Git patches, auto-commits and runs tests for iterative fixes, reducing manual edits [1][2]."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Simple installation via pip and open-source usage, but requires command-line familiarity and API keys [1][2]."
+  },
+  "code_quality_testing": {
+    "rating": 4,
+    "reasoning": "Can run unit tests automatically and propose corrections based on failures, improving reliability [2]."
+  },
+  "codebase_comprehension": {
+    "rating": 4,
+    "reasoning": "LLM-enabled to edit multiple files with context and apply patches across a repository, aiding navigation [1][2]."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 1,
+    "reasoning": "Focuses on text-based code editing without built-in image or audio features."
+  },
+  "data_experimental_flexibility": {
+    "rating": 2,
+    "reasoning": "Supports multiple LLM backends including local models, but lacks broader data or experiment management features [1]."
+  },
+  "visual_no_code_development": {
+    "rating": 1,
+    "reasoning": "Terminal-centric workflow with no drag-and-drop or visual builders."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 2,
+    "reasoning": "Provides basic git integration but no tools for orchestrating multi-agent pipelines or CI/CD [1][2]."
+  }
+}


### PR DESCRIPTION
## Summary
- Add persona ratings for the Aider coding assistant across eight persona criteria.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689baf09d77c8321b97b2ad4c623cb01