### PR TITLE
Add v0 app agent profile and persona criteria

### DIFF
--- a/agents.json
+++ b/agents.json
@@ -27,7 +27,7 @@
       "benchmarks": {
         "swe_bench_score": 49,
         "swe_bench_source": "https://www.anthropic.com/research/swe-bench-sonnet",
-        "terminal_bench_score": "43.2% \u00b1 1.3",
+        "terminal_bench_score": "43.2% ± 1.3",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard",
         "task_success_rate": 0.432,
         "resource_usage": "Not publicly documented"
@@ -57,7 +57,7 @@
       ],
       "pricing_model": "Requires an OpenAI API key or a paid OpenAI account (Plus/Pro).",
       "benchmarks": {
-        "terminal_bench_score": "20.0% \u00b1 1.5",
+        "terminal_bench_score": "20.0% ± 1.5",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard",
         "task_success_rate": 0.2,
         "resource_usage": "Runs locally; resource usage depends on chosen model"
@@ -111,7 +111,7 @@
       ],
       "pricing_model": "Open-source",
       "benchmarks": {
-        "terminal_bench_score": "42.0% \u00b1 1.3",
+        "terminal_bench_score": "42.0% ± 1.3",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard",
         "task_success_rate": 0.42,
         "resource_usage": "Depends on local hardware and model; no public metrics"
@@ -1037,6 +1037,30 @@
         "documentation_quality": null,
         "onboarding_experience": null
       }
+    },
+    {
+      "name": "v0",
+      "website": "https://v0.app/",
+      "developer": "Vercel",
+      "key_features": [
+        "Generates React/Next.js UI from natural language prompts",
+        "Allows iterative refinement of designs with code export",
+        "Provides ready-to-use Tailwind CSS components"
+      ],
+      "supported_models": [
+        "Not specified (leverages OpenAI models)"
+      ],
+      "pricing_model": "Free tier with paid usage-based plans",
+      "benchmarks": {
+        "swe_bench_score": null,
+        "task_success_rate": null,
+        "resource_usage": ""
+      },
+      "qualitative_assessment": {
+        "ease_of_use": null,
+        "documentation_quality": null,
+        "onboarding_experience": null
+      }
     }
   ],
   "agent_frameworks": [
@@ -1136,7 +1160,7 @@
       ],
       "pricing_model": "Cloud-based platform with a free tier and enterprise options.",
       "benchmarks": {
-        "terminal_bench_score": "42.5% \u00b1 0.8",
+        "terminal_bench_score": "42.5% ± 0.8",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard"
       },
       "qualitative_assessment": {
@@ -1186,7 +1210,7 @@
       ],
       "pricing_model": "Open-source under the MIT License; free for self-hosting with optional paid hosting via Daytona",
       "benchmarks": {
-        "terminal_bench_score": "41.3% \u00b1 0.7",
+        "terminal_bench_score": "41.3% ± 0.7",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard",
         "task_success_rate": 0.413,
         "resource_usage": "Not publicly documented; depends on hosting environment and model"
@@ -1246,7 +1270,7 @@
       ],
       "pricing_model": "Research project, likely free to use.",
       "benchmarks": {
-        "terminal_bench_score": "39.9% \u00b1 1.0",
+        "terminal_bench_score": "39.9% ± 1.0",
         "terminal_bench_source": "https://www.tbench.ai/leaderboard",
         "task_success_rate": 0.399,
         "resource_usage": "Not publicly documented; depends on remote environment and model"

--- a/agents/v0.app/persona_criteria_v0.app.json
+++ b/agents/v0.app/persona_criteria_v0.app.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Generates front-end code rapidly, reducing manual UI development time."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 4,
+    "reasoning": "Web-based interface with prompt-driven workflow and minimal setup."
+  },
+  "code_quality_testing": {
+    "rating": 1,
+    "reasoning": "Focuses on prototyping without built-in testing capabilities."
+  },
+  "codebase_comprehension": {
+    "rating": 2,
+    "reasoning": "Produces isolated components but does not analyze existing codebases."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 4,
+    "reasoning": "Supports visual and textual exploration of interface ideas."
+  },
+  "data_experimental_flexibility": {
+    "rating": 2,
+    "reasoning": "Limited integration with external data sources for experiments."
+  },
+  "visual_no_code_development": {
+    "rating": 5,
+    "reasoning": "Designed for prompt-based UI creation with copyable React components."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 1,
+    "reasoning": "Does not provide tools for multi-agent workflows or CI/CD orchestration."
+  }
+}

--- a/agents/v0.app/profile.md
+++ b/agents/v0.app/profile.md
@@ -1,0 +1,33 @@
+# v0
+
+## Overview
+
+v0 is a generative UI builder that turns natural language prompts into production-ready React and Tailwind components.
+
+## Key Information
+
+- **Developer:** Vercel
+- **Website:** [https://v0.app/](https://v0.app/)
+- **Pricing:** Free tier with paid usage-based plans
+
+## Key Features
+
+- **Prompt-to-interface:** Generates React/Next.js UI from natural language descriptions.
+- **Iterative refinement:** Chat-based adjustments with copyable code exports.
+- **Tailwind components:** Provides styled components ready for integration.
+
+## Supported Models
+
+- Not publicly documented (leverages OpenAI models)
+
+## Benchmarks
+
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+
+- **Ease of Use:** Not available
+- **Documentation Quality:** Not available
+- **Onboarding Experience:** Not available


### PR DESCRIPTION
## Summary
- add v0 to agent catalog with site, features, and model info
- document v0’s capabilities in a new profile
- evaluate v0 against existing persona criteria

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c3aa4f5c0832184af5f63aa18a960