### PR TITLE
Add missing agent profiles and refine Engine ratings

### DIFF
--- a/agents/CodeGPT/profile.md
+++ b/agents/CodeGPT/profile.md
@@ -1,0 +1,38 @@
+# CodeGPT
+
+## Overview
+
+CodeGPT is an AI agent platform for software development from Judini Inc. It provides chat-based tooling that can review pull requests, onboard developers, and generate or refactor code with context from an entire repository.
+
+## Key Information
+
+- **Developer:** Judini Inc
+- **Website:** [https://codegpt.co/](https://codegpt.co/)
+- **Pricing:** Tiered plans (Free, Plus, Enterprise)
+
+## Key Features
+
+- AI agent marketplace and custom agent creation
+- Automated pull request reviews and code suggestions
+- Knowledge Graph Codebase for repository-wide context
+- Chat commands for fixing, documenting, and refactoring code
+- SOC2 Type II compliance and optional self-hosting
+
+## Supported Models
+
+- OpenAI
+- Anthropic
+- Google Gemini
+- Meta Llama
+
+## Benchmarks
+
+- **SWE-bench score:** No published results
+- **Task Success Rate:** Not publicly reported
+- **Resource Usage:** Not publicly documented
+
+## Qualitative Assessment
+
+- **Ease of Use:** Extensions for popular IDEs and simple chat commands make it accessible
+- **Documentation Quality:** Quick start guides and tutorials cover setup and key workflows
+- **Onboarding Experience:** Free tier and bring-your-own-key support enable fast experimentation

--- a/agents/Engine/persona_ratings_engine.json
+++ b/agents/Engine/persona_ratings_engine.json
@@ -1,34 +1,34 @@
 {
   "automation_productivity": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 5,
+    "reasoning": "Engine turns issues into pull requests, responds to code reviews and CI/CD, and can operate in autopilot in its own VM, reducing manual work."
   },
   "beginner_friendly_onboarding": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "Tiered plans and web onboarding make start simple, but understanding integration with project tools requires some expertise."
   },
   "code_quality_testing": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 4,
+    "reasoning": "The agent reacts to code reviews and CI actions to ensure generated changes pass checks, though it lacks dedicated test generation."
   },
   "codebase_comprehension": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 4,
+    "reasoning": "Engine works inside a full development environment and uses repository context to modify code and produce targeted pull requests."
   },
   "creative_multimodal_exploration": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 1,
+    "reasoning": "The platform is focused on software engineering and does not handle images, audio, or other creative modalities."
   },
   "data_experimental_flexibility": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "Supports multiple LLMs and service integrations but has no built-in tools for data science experimentation or tracking."
   },
   "visual_no_code_development": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "Provides a browser IDE to collaborate with the agent, yet development remains code-centric without drag-and-drop interfaces."
   },
   "workflow_agent_orchestration": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 5,
+    "reasoning": "Designed for workflow automation with integrations to Linear, Jira, Slack, and Git platforms, enabling autonomous end-to-end task execution."
   }
 }

--- a/agents/Engine/profile.md
+++ b/agents/Engine/profile.md
@@ -1,0 +1,38 @@
+# Engine
+
+## Overview
+
+Engine is a remote AI software engineer from Engine Labs that works in an isolated virtual machine to turn issues into pull requests. It integrates with popular project management tools and can run in autopilot mode to respond to code reviews and CI/CD events.
+
+## Key Information
+
+- **Developer:** Engine Labs
+- **Website:** [https://enginelabs.ai/](https://enginelabs.ai/)
+- **Pricing:** Tiered plans (Intern, Junior, Senior, Staff)
+
+## Key Features
+
+- Remote AI engineer operating in its own development environment
+- Automatically turns issues from tools like Linear or Jira into pull requests
+- Responds to code reviews and CI/CD actions
+- Integrates with GitHub, GitLab, Slack, Trello, and more
+- Includes a browser-based IDE for collaborating with the agent
+- Optional autopilot mode for fully autonomous operation
+
+## Supported Models
+
+- Anthropic Claude 4
+- OpenAI o3
+- Google models
+
+## Benchmarks
+
+- **Terminal-bench score:** #2 on the [Terminal-Bench leaderboard](https://www.tbench.ai/leaderboard)
+- **Task Success Rate:** Not publicly reported
+- **Resource Usage:** Not publicly documented
+
+## Qualitative Assessment
+
+- **Ease of Use:** Web IDE and deep integrations reduce setup and make collaboration straightforward
+- **Documentation Quality:** Public docs describe configuration, integrations, and best practices
+- **Onboarding Experience:** Tiered plans and SaaS-style onboarding streamline getting started for teams

--- a/agents/Letta/profile.md
+++ b/agents/Letta/profile.md
@@ -1,0 +1,35 @@
+# Letta
+
+## Overview
+
+Letta is a platform for building stateful AI agents that retain long-term memory and expose their capabilities through REST APIs. Built on MemGPT, it offers tools to visualize agent reasoning and integrate custom tools across multiple frameworks.
+
+## Key Information
+
+- **Developer:** Letta
+- **Website:** [https://www.letta.com/](https://www.letta.com/)
+- **Pricing:** Cloud platform with a free tier and enterprise plans
+
+## Key Features
+
+- Stateful agents with advanced memory and virtually infinite context
+- Agent Development Environment (ADE) to inspect memory, reasoning, and tool calls
+- Agents deployed as REST API endpoints
+- Support for custom tools and Model Context Protocol (MCP)
+- Framework agnostic: Python, Node.js, Vercel AI SDK, Next.js, React
+
+## Supported Models
+
+- Model-agnostic; supports multiple LLM providers
+
+## Benchmarks
+
+- **Terminal-bench score:** 42.5% ± 0.8 on the [Terminal-Bench leaderboard](https://www.tbench.ai/leaderboard)
+- **Task Success Rate:** Not publicly reported
+- **Resource Usage:** Not publicly documented
+
+## Qualitative Assessment
+
+- **Ease of Use:** Visual ADE and clear APIs make agent development approachable
+- **Documentation Quality:** Comprehensive docs and a free course provide guidance
+- **Onboarding Experience:** Generous free tier and quickstart examples enable smooth adoption

--- a/agents/android_studio_bot/profile.md
+++ b/agents/android_studio_bot/profile.md
@@ -1,0 +1,42 @@
+# Android Studio Bot
+
+## Overview
+
+Android Studio Bot is an AI-powered conversational experience integrated into Android Studio. It is designed to make Android developers more productive by helping them generate code, answer questions, and fix errors.
+
+## Key Information
+
+- **Developer:** Google
+- **Website:** [https://developer.android.com/studio](https://developer.android.com/studio)
+- **Pricing:** Included with Android Studio
+
+## Key Features
+
+- **AI-powered conversational experience:** Chat with Studio Bot to get help with your code.
+- **Code generation:** Generate code for your app.
+- **Q&A:** Ask questions about Android development.
+- **Error fixing:** Get help with fixing errors in your code.
+
+## Supported Models
+
+- Codey (descendant of PaLM 2)
+
+## Benchmarks
+
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+
+- **Ease of Use:** High
+- **Documentation Quality:** High
+- **Onboarding Experience:** Straightforward
+
+## Pricing
+
+Android Studio Bot is a free feature integrated into Android Studio.
+
+## Getting Started
+
+To get started with Android Studio Bot, you can download the latest version of Android Studio and enable the feature in the settings. For more information, you can refer to the [official announcement blog post](https://android-developers.googleblog.com/2023/05/android-studio-io-23-announcing-studio-bot.html).

--- a/agents/minimax_agent/profile.md
+++ b/agents/minimax_agent/profile.md
@@ -1,0 +1,37 @@
+# Minimax Agent
+
+## Overview
+
+Minimax Agent is part of the MiniMax platform, providing multimodal AI capabilities for text, audio, and video generation. It leverages large context windows and specialized models to build autonomous applications and creative experiences.
+
+## Key Information
+
+- **Developer:** MiniMax
+- **Website:** [https://www.minimaxi.com/](https://www.minimaxi.com/)
+- **Pricing:** Usage-based API pricing
+
+## Key Features
+
+- MiniMax M1 text model with 1 million token input window
+- Hailuo 02 video model for 1080p generation
+- Speech 02 model for high-quality speech synthesis and voice cloning
+- MCP server and toolkits for video, image, and speech workflows
+- Suite of AI-native applications such as MiniMax Chat and Talkie
+
+## Supported Models
+
+- MiniMax M1 (Text)
+- MiniMax Hailuo 02 (Video)
+- MiniMax Speech 02 (Audio)
+
+## Benchmarks
+
+- **SWE-bench score:** No published results
+- **Task Success Rate:** Not publicly reported
+- **Resource Usage:** No public benchmarks available
+
+## Qualitative Assessment
+
+- **Ease of Use:** API-first platform aimed at developers; sample apps aid initial setup
+- **Documentation Quality:** Official docs cover model APIs, though some sections remain untranslated
+- **Onboarding Experience:** Requires API key and code integration; no-code options are limited

--- a/agents/swe_agent/profile.md
+++ b/agents/swe_agent/profile.md
@@ -1,0 +1,44 @@
+# SWE-agent
+
+## Overview
+
+SWE-agent is an open-source, cloud-based coding agent from LangChain that can autonomously understand, plan, and execute code changes across entire repositories. It is built with LangGraph and features a multi-agent architecture.
+
+## Key Information
+
+- **Developer:** LangChain
+- **Website:** [https://github.com/langchain-ai/open-swe](https://github.com/langchain-ai/open-swe)
+- **Pricing:** Open-source, with users paying for the underlying model APIs.
+
+## Key Features
+
+- **Autonomous code changes:** Understands, plans, and executes code changes across entire repositories.
+- **Multi-agent architecture:** Uses a Manager, Planner, and Programmer to orchestrate the workflow.
+- **Human-in-the-loop:** Allows for manual review and approval of the execution plan.
+- **Cloud-based and asynchronous:** Runs in the acloud and can work on multiple tasks in parallel.
+- **GitHub integration:** Can be triggered by GitHub webhooks and opens pull requests when done.
+
+## Supported Models
+
+- Anthropic's models (e.g., Claude)
+
+## Benchmarks
+
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+
+- **Ease of Use:** High
+- **Documentation Quality:** High
+- **Onboarding Experience:** Straightforward
+
+## Pricing
+
+Open SWE is an open-source project. The hosted version at [swe.langchain.com](https://swe.langchain.com/) requires an Anthropic API key, so the pricing is based on the usage of the underlying model.
+
+## Getting Started
+
+To get started with Open SWE, you can visit the [official website](https://swe.langchain.com/) or check out the [GitHub repository](https://github.com/langchain-ai/open-swe).
+


### PR DESCRIPTION
## Summary
- add profile markdown files for CodeGPT, Engine, Letta, Android Studio Bot, Minimax Agent, and SWE-agent
- replace placeholder persona ratings for Engine with detailed assessments

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689c3b3e44f0832188a99d38810d0bb0