### PR TITLE
Remove qualitative assessment from agent JSON files

### DIFF
--- a/agents.schema.json
+++ b/agents.schema.json
@@ -6,72 +6,114 @@
   "properties": {
     "terminal_based": {
       "type": "array",
-      "items": { "$ref": "#/definitions/agent" }
+      "items": {
+        "$ref": "#/definitions/agent"
+      }
     },
     "ide_embedded": {
       "type": "array",
-      "items": { "$ref": "#/definitions/agent" }
+      "items": {
+        "$ref": "#/definitions/agent"
+      }
     },
     "web_virtualized": {
       "type": "array",
-      "items": { "$ref": "#/definitions/agent" }
+      "items": {
+        "$ref": "#/definitions/agent"
+      }
     },
     "agent_frameworks": {
       "type": "array",
-      "items": { "$ref": "#/definitions/agent" }
+      "items": {
+        "$ref": "#/definitions/agent"
+      }
     }
   },
-  "required": ["terminal_based", "ide_embedded", "web_virtualized", "agent_frameworks"],
+  "required": [
+    "terminal_based",
+    "ide_embedded",
+    "web_virtualized",
+    "agent_frameworks"
+  ],
   "definitions": {
     "agent": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "name": { "type": "string" },
-        "website": { "type": ["string", "null"] },
-        "developer": { "type": ["string", "null"] },
+        "name": {
+          "type": "string"
+        },
+        "website": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "developer": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "key_features": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "supported_models": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
-        "pricing_model": { "type": ["string", "null"] },
+        "pricing_model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "benchmarks": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "swe_bench_score": { "type": ["number", "string", "null"] },
-            "swe_bench_source": { "type": ["string", "null"] },
-            "terminal_bench_score": { "type": ["number", "string", "null"] },
-            "terminal_bench_source": { "type": ["string", "null"] },
-            "task_success_rate": { "type": ["number", "null"] },
-            "resource_usage": { "type": ["string", "null"] }
-          }
-        },
-        "qualitative_assessment": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "ease_of_use": {
-              "description": "Rating of how easy the agent is to use (1=low, 3=high)",
-              "type": ["integer", "null"],
-              "minimum": 1,
-              "maximum": 3
+            "swe_bench_score": {
+              "type": [
+                "number",
+                "string",
+                "null"
+              ]
             },
-            "documentation_quality": {
-              "description": "Rating of how comprehensive the documentation is (1=poor, 3=excellent)",
-              "type": ["integer", "null"],
-              "minimum": 1,
-              "maximum": 3
+            "swe_bench_source": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "onboarding_experience": {
-              "description": "Rating of the onboarding experience (1=difficult, 3=very easy)",
-              "type": ["integer", "null"],
-              "minimum": 1,
-              "maximum": 3
+            "terminal_bench_score": {
+              "type": [
+                "number",
+                "string",
+                "null"
+              ]
+            },
+            "terminal_bench_source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "task_success_rate": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "resource_usage": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           }
         }
@@ -81,8 +123,7 @@
         "key_features",
         "supported_models",
         "pricing_model",
-        "benchmarks",
-        "qualitative_assessment"
+        "benchmarks"
       ]
     }
   }

--- a/agents/Aider/agent_Aider.json
+++ b/agents/Aider/agent_Aider.json
@@ -19,10 +19,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Amazon_CodeGuru/agent_Amazon_CodeGuru.json
+++ b/agents/Amazon_CodeGuru/agent_Amazon_CodeGuru.json
@@ -22,10 +22,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Amazon_CodeWhisperer/agent_Amazon_CodeWhisperer.json
+++ b/agents/Amazon_CodeWhisperer/agent_Amazon_CodeWhisperer.json
@@ -21,10 +21,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Android_Studio_Bot/agent_Android_Studio_Bot.json
+++ b/agents/Android_Studio_Bot/agent_Android_Studio_Bot.json
@@ -17,10 +17,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/AskCodi/agent_AskCodi.json
+++ b/agents/AskCodi/agent_AskCodi.json
@@ -31,10 +31,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/ChatGPT_agent/agent_ChatGPT_agent.json
+++ b/agents/ChatGPT_agent/agent_ChatGPT_agent.json
@@ -18,10 +18,5 @@
     "swe_bench_source": "https://cognition.ai/blog/swe-bench-technical-report",
     "task_success_rate": null,
     "resource_usage": "GPT-4 (assisted). GPT-3.5 (assisted) scored 1.34% on SWE-bench"
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Claude_Code/agent_Claude_Code.json
+++ b/agents/Claude_Code/agent_Claude_Code.json
@@ -29,10 +29,5 @@
     "terminal_bench_source": "https://www.tbench.ai/leaderboard",
     "task_success_rate": 0.432,
     "resource_usage": "Not publicly documented"
-  },
-  "qualitative_assessment": {
-    "ease_of_use": 3,
-    "documentation_quality": 3,
-    "onboarding_experience": 3
   }
 }

--- a/agents/Cline/agent_Cline.json
+++ b/agents/Cline/agent_Cline.json
@@ -20,10 +20,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/CodeGPT/agent_CodeGPT.json
+++ b/agents/CodeGPT/agent_CodeGPT.json
@@ -21,10 +21,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/CodeWP/agent_CodeWP.json
+++ b/agents/CodeWP/agent_CodeWP.json
@@ -17,10 +17,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Codex_CLI/agent_Codex_CLI.json
+++ b/agents/Codex_CLI/agent_Codex_CLI.json
@@ -21,10 +21,5 @@
     "terminal_bench_source": "https://www.tbench.ai/leaderboard",
     "task_success_rate": 0.2,
     "resource_usage": "Runs locally; resource usage depends on chosen model"
-  },
-  "qualitative_assessment": {
-    "ease_of_use": 3,
-    "documentation_quality": 3,
-    "onboarding_experience": 2
   }
 }

--- a/agents/CrewAI/agent_CrewAI.json
+++ b/agents/CrewAI/agent_CrewAI.json
@@ -20,10 +20,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Cursor/agent_Cursor.json
+++ b/agents/Cursor/agent_Cursor.json
@@ -28,10 +28,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/DeepCode_AI/agent_DeepCode_AI.json
+++ b/agents/DeepCode_AI/agent_DeepCode_AI.json
@@ -24,10 +24,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Gemini_CLI/agent_Gemini_CLI.json
+++ b/agents/Gemini_CLI/agent_Gemini_CLI.json
@@ -19,10 +19,5 @@
     "swe_bench_source": "https://www.swebench.com/",
     "task_success_rate": null,
     "resource_usage": "Not publicly documented"
-  },
-  "qualitative_assessment": {
-    "ease_of_use": 3,
-    "documentation_quality": 3,
-    "onboarding_experience": 3
   }
 }

--- a/agents/GitHub_Copilot/agent_GitHub_Copilot.json
+++ b/agents/GitHub_Copilot/agent_GitHub_Copilot.json
@@ -33,10 +33,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Goose/agent_Goose.json
+++ b/agents/Goose/agent_Goose.json
@@ -17,10 +17,5 @@
     "terminal_bench_source": "https://www.tbench.ai/leaderboard",
     "task_success_rate": 0.42,
     "resource_usage": "Depends on local hardware and model; no public metrics"
-  },
-  "qualitative_assessment": {
-    "ease_of_use": 2,
-    "documentation_quality": 3,
-    "onboarding_experience": 2
   }
 }

--- a/agents/Jules/agent_Jules.json
+++ b/agents/Jules/agent_Jules.json
@@ -20,10 +20,5 @@
     "swe_bench_source": "https://aiagentindex.mit.edu/jules/",
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Kilo/agent_Kilo.json
+++ b/agents/Kilo/agent_Kilo.json
@@ -13,10 +13,5 @@
     "swe_bench_score": "Not found",
     "task_success_rate": null,
     "resource_usage": "Not found"
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/LangChain/agent_LangChain.json
+++ b/agents/LangChain/agent_LangChain.json
@@ -17,10 +17,5 @@
     "swe_bench_score": 0.486,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/LangGraph/agent_LangGraph.json
+++ b/agents/LangGraph/agent_LangGraph.json
@@ -15,10 +15,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Letta/agent_Letta.json
+++ b/agents/Letta/agent_Letta.json
@@ -17,10 +17,5 @@
   "benchmarks": {
     "terminal_bench_score": "42.5% ± 0.8",
     "terminal_bench_source": "https://www.tbench.ai/leaderboard"
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/LogiQCLI/agent_LogiQCLI.json
+++ b/agents/LogiQCLI/agent_LogiQCLI.json
@@ -18,10 +18,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": "Not publicly documented"
-  },
-  "qualitative_assessment": {
-    "ease_of_use": 3,
-    "documentation_quality": 3,
-    "onboarding_experience": 3
   }
 }

--- a/agents/Minimax_agent/agent_Minimax_agent.json
+++ b/agents/Minimax_agent/agent_Minimax_agent.json
@@ -19,10 +19,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": "No public benchmarks found"
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/OpenAI_Codex/agent_OpenAI_Codex.json
+++ b/agents/OpenAI_Codex/agent_OpenAI_Codex.json
@@ -15,10 +15,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": "Depends on API usage; no public metrics"
-  },
-  "qualitative_assessment": {
-    "ease_of_use": 2,
-    "documentation_quality": 2,
-    "onboarding_experience": 2
   }
 }

--- a/agents/OpenHands/agent_OpenHands.json
+++ b/agents/OpenHands/agent_OpenHands.json
@@ -18,10 +18,5 @@
     "terminal_bench_source": "https://www.tbench.ai/leaderboard",
     "task_success_rate": 0.413,
     "resource_usage": "Not publicly documented; depends on hosting environment and model"
-  },
-  "qualitative_assessment": {
-    "ease_of_use": 2,
-    "documentation_quality": 3,
-    "onboarding_experience": 2
   }
 }

--- a/agents/Perplexity_Labs/agent_Perplexity_Labs.json
+++ b/agents/Perplexity_Labs/agent_Perplexity_Labs.json
@@ -15,10 +15,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Qwen_CLI/agent_Qwen_CLI.json
+++ b/agents/Qwen_CLI/agent_Qwen_CLI.json
@@ -16,10 +16,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": "Not publicly documented"
-  },
-  "qualitative_assessment": {
-    "ease_of_use": 3,
-    "documentation_quality": 3,
-    "onboarding_experience": 3
   }
 }

--- a/agents/Replit_AI/agent_Replit_AI.json
+++ b/agents/Replit_AI/agent_Replit_AI.json
@@ -22,10 +22,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Roo_Code/agent_Roo_Code.json
+++ b/agents/Roo_Code/agent_Roo_Code.json
@@ -15,10 +15,5 @@
     "swe_bench_score": "Not applicable",
     "task_success_rate": null,
     "resource_usage": "Not applicable"
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/SQLAI/agent_SQLAI.json
+++ b/agents/SQLAI/agent_SQLAI.json
@@ -17,10 +17,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/SWE-agent/agent_SWE-agent.json
+++ b/agents/SWE-agent/agent_SWE-agent.json
@@ -24,10 +24,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Sourcegraph_Cody/agent_Sourcegraph_Cody.json
+++ b/agents/Sourcegraph_Cody/agent_Sourcegraph_Cody.json
@@ -24,10 +24,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Tabnine/agent_Tabnine.json
+++ b/agents/Tabnine/agent_Tabnine.json
@@ -23,10 +23,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Terminus/agent_Terminus.json
+++ b/agents/Terminus/agent_Terminus.json
@@ -18,10 +18,5 @@
     "terminal_bench_source": "https://www.tbench.ai/leaderboard",
     "task_success_rate": 0.399,
     "resource_usage": "Not publicly documented; depends on remote environment and model"
-  },
-  "qualitative_assessment": {
-    "ease_of_use": 1,
-    "documentation_quality": 1,
-    "onboarding_experience": 1
   }
 }

--- a/agents/Trae/agent_Trae.json
+++ b/agents/Trae/agent_Trae.json
@@ -24,10 +24,5 @@
     "swe_bench_source": "https://www.datacamp.com/tutorial/trae-ai",
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/Warp/agent_Warp.json
+++ b/agents/Warp/agent_Warp.json
@@ -25,10 +25,5 @@
     "task_success_rate": 0.52,
     "resource_usage": "Not publicly documented; depends on local hardware and active agents",
     "swe_bench_score": "71%"
-  },
-  "qualitative_assessment": {
-    "ease_of_use": 3,
-    "documentation_quality": 3,
-    "onboarding_experience": 3
   }
 }

--- a/agents/chat.z.ai/agent_chat.z.ai.json
+++ b/agents/chat.z.ai/agent_chat.z.ai.json
@@ -19,10 +19,5 @@
     "swe_bench_score": 64.2,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/devin/agent_devin.json
+++ b/agents/devin/agent_devin.json
@@ -19,10 +19,5 @@
     "swe_bench_score": 13.86,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/enginelabs/agent_enginelabs.json
+++ b/agents/enginelabs/agent_enginelabs.json
@@ -23,10 +23,5 @@
     "terminal_bench_source": "https://www.tbench.ai/leaderboard",
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/manus/agent_manus.json
+++ b/agents/manus/agent_manus.json
@@ -15,10 +15,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/mini-SWE-agent/agent_mini-SWE-agent.json
+++ b/agents/mini-SWE-agent/agent_mini-SWE-agent.json
@@ -16,10 +16,5 @@
     "swe_bench_source": "https://swe-agent.com/",
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/v0.app/agent_v0.app.json
+++ b/agents/v0.app/agent_v0.app.json
@@ -15,10 +15,5 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }

--- a/agents/z.ai/agent_z.ai.json
+++ b/agents/z.ai/agent_z.ai.json
@@ -20,10 +20,5 @@
     "swe_bench_score": 64.2,
     "task_success_rate": null,
     "resource_usage": ""
-  },
-  "qualitative_assessment": {
-    "ease_of_use": null,
-    "documentation_quality": null,
-    "onboarding_experience": null
   }
 }


### PR DESCRIPTION
## Summary
- drop `qualitative_assessment` from all agent_*.json files
- update `agents.schema.json` to remove now-unused property and required entry

## Testing
- `python - <<'PY'
import jsonschema, json, glob
schema = json.load(open('agents.schema.json'))
files = glob.glob('agents/*/agent_*.json')
for f in files:
    data = json.load(open(f))
    jsonschema.validate(instance=data, schema=schema['definitions']['agent'])
print('validated', len(files), 'files')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689c4eacc9d88321bbfe99503acdcf83