### PR TITLE
Add Figma Make agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The following agents have been profiled in this repository:
 - CodeWP
 - Cursor
 - DeepCode AI
+- Figma Make
 - GitHub Copilot
 - Kilo
 - Replit AI

--- a/agents/Figma_Make/agent_Figma_Make.json
+++ b/agents/Figma_Make/agent_Figma_Make.json
@@ -1,0 +1,20 @@
+{
+  "name": "Figma Make",
+  "website": "https://www.figma.com/ai/",
+  "developer": "Figma Inc.",
+  "key_features": [
+    "Generate UI mockups from text prompts using 'Make Designs'",
+    "Automatically build interactive flows with 'Make Prototypes'",
+    "Produce placeholder copy and imagery for designs",
+    "Leverage existing components and auto layout for consistency"
+  ],
+  "supported_models": [
+    "Proprietary Figma generative models (details undisclosed)"
+  ],
+  "pricing_model": "Included with Figma subscription; AI features currently in beta",
+  "benchmarks": {
+    "swe_bench_score": null,
+    "task_success_rate": null,
+    "resource_usage": ""
+  }
+}

--- a/agents/Figma_Make/persona_ratings_figma_make.json
+++ b/agents/Figma_Make/persona_ratings_figma_make.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Generates designs and prototypes from prompts, reducing manual drafting."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 4,
+    "reasoning": "Runs inside Figma's familiar interface with guided prompts."
+  },
+  "code_quality_testing": {
+    "rating": 1,
+    "reasoning": "Focused on design generation and lacks code testing features."
+  },
+  "codebase_comprehension": {
+    "rating": 2,
+    "reasoning": "Understands design systems and components but not source code."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 4,
+    "reasoning": "Supports text-to-design and image generation for creative exploration."
+  },
+  "data_experimental_flexibility": {
+    "rating": 2,
+    "reasoning": "Limited controls over model parameters or dataset customization."
+  },
+  "visual_no_code_development": {
+    "rating": 5,
+    "reasoning": "Enables drag-and-drop design and prototyping without coding."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 2,
+    "reasoning": "Integrates with Figma projects but lacks broader automation orchestration."
+  }
+}

--- a/agents/Figma_Make/profile.md
+++ b/agents/Figma_Make/profile.md
@@ -1,0 +1,34 @@
+# Figma Make
+
+## Overview
+
+Figma Make is an AI assistant built into Figma that transforms text prompts into design files. It can create mockups, prototypes, and filler content to accelerate interface design.
+
+## Key Information
+
+- **Developer:** Figma Inc.
+- **Website:** [https://www.figma.com/ai/](https://www.figma.com/ai/)
+- **Pricing:** Included with Figma subscription; AI features currently in beta
+
+## Key Features
+
+- **Make Designs:** Generate UI layouts from natural language descriptions.
+- **Make Prototypes:** Automatically wire screens into interactive flows.
+- **Content generation:** Drafts copy and placeholder imagery inside designs.
+- **Design system aware:** Reuses existing components and applies auto layout.
+
+## Supported Models
+
+- Proprietary Figma generative models (details undisclosed)
+
+## Benchmarks
+
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+
+- **Ease of Use:** Not available
+- **Documentation Quality:** Not available
+- **Onboarding Experience:** Not available


### PR DESCRIPTION
## Summary
- add Figma Make agent profile with metadata, persona ratings, and overview
- document Figma Make among IDE-Embedded Agents

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c52821eac8321abe4c89e5dd47f77