### PR TITLE
Add Open SWE agent profile and metadata

### DIFF
--- a/agents/swe_agent/agent_swe_agent.json
+++ b/agents/swe_agent/agent_swe_agent.json
@@ -1,0 +1,24 @@
+{
+  "name": "Open SWE",
+  "website": "https://github.com/langchain-ai/open-swe",
+  "developer": "LangChain",
+  "key_features": [
+    "Open-source asynchronous coding agent built with LangGraph",
+    "Dedicated planning step with optional human approval",
+    "Multi-agent architecture coordinating Manager, Planner, Programmer, and Reviewer roles",
+    "Parallel cloud execution in an isolated sandbox",
+    "End-to-end GitHub workflow that creates issues, runs tests, reviews code, and opens pull requests"
+  ],
+  "supported_models": [
+    "Anthropic Claude models (user-supplied API key)"
+  ],
+  "pricing_model": "Open-source; hosted demo requires users to pay for underlying model usage via their API keys.",
+  "benchmarks": {
+    "swe_bench_score": null,
+    "swe_bench_source": null,
+    "terminal_bench_score": null,
+    "terminal_bench_source": null,
+    "task_success_rate": null,
+    "resource_usage": null
+  }
+}

--- a/agents/swe_agent/profile.md
+++ b/agents/swe_agent/profile.md
@@ -1,26 +1,26 @@
-# SWE-agent
+# Open SWE
 
 ## Overview
 
-SWE-agent is an open-source, cloud-based coding agent from LangChain that can autonomously understand, plan, and execute code changes across entire repositories. It is built with LangGraph and features a multi-agent architecture.
+Open SWE is an open-source, asynchronous coding agent from LangChain. Built on the LangGraph framework, it autonomously analyzes repositories, plans changes, and implements code updates while running in a cloud-hosted sandbox.
 
 ## Key Information
 
 - **Developer:** LangChain
 - **Website:** [https://github.com/langchain-ai/open-swe](https://github.com/langchain-ai/open-swe)
-- **Pricing:** Open-source, with users paying for the underlying model APIs.
+- **Pricing:** Open-source; hosted demo requires users to supply their own LLM API keys.
 
 ## Key Features
 
-- **Autonomous code changes:** Understands, plans, and executes code changes across entire repositories.
-- **Multi-agent architecture:** Uses a Manager, Planner, and Programmer to orchestrate the workflow.
-- **Human-in-the-loop:** Allows for manual review and approval of the execution plan.
-- **Cloud-based and asynchronous:** Runs in the acloud and can work on multiple tasks in parallel.
-- **GitHub integration:** Can be triggered by GitHub webhooks and opens pull requests when done.
+- **Planning with human approval:** Generates a detailed execution plan that users can accept, modify, or reject.
+- **Multi-agent architecture:** Manager, Planner, Programmer, and Reviewer agents coordinate to complete tasks.
+- **End-to-end GitHub workflow:** Automatically creates issues, runs tests, reviews its own changes, and opens pull requests.
+- **Parallel cloud execution:** Tasks run asynchronously in a sandbox and multiple jobs can execute in parallel.
+- **Real-time feedback:** Users can message the agent during planning or execution to guide progress.
 
 ## Supported Models
 
-- Anthropic's models (e.g., Claude)
+- Anthropic Claude models (user-provided API key; other LLMs can be configured)
 
 ## Benchmarks
 
@@ -36,9 +36,9 @@ SWE-agent is an open-source, cloud-based coding agent from LangChain that can au
 
 ## Pricing
 
-Open SWE is an open-source project. The hosted version at [swe.langchain.com](https://swe.langchain.com/) requires an Anthropic API key, so the pricing is based on the usage of the underlying model.
+Open SWE is free and open-source. The hosted demo at [swe.langchain.com](https://swe.langchain.com/) requires users to pay for LLM usage via their API keys.
 
 ## Getting Started
 
-To get started with Open SWE, you can visit the [official website](https://swe.langchain.com/) or check out the [GitHub repository](https://github.com/langchain-ai/open-swe).
+Visit the [GitHub repository](https://github.com/langchain-ai/open-swe) for source code and documentation, or try the [public demo](https://swe.langchain.com/) after providing your LLM API keys.
 


### PR DESCRIPTION
## Summary
- document Open SWE coding agent with planning, multi-agent architecture, and GitHub workflow
- add structured metadata for Open SWE including features, supported models, and pricing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c57ccb64883218497517caa5d0c8f