### PR TITLE
Add Minimax Agent profile and metadata

### DIFF
--- a/agents/minimax_agent/agent_minimax_agent.json
+++ b/agents/minimax_agent/agent_minimax_agent.json
@@ -1,0 +1,23 @@
+{
+  "name": "Minimax Agent",
+  "website": "https://www.minimaxi.com/",
+  "developer": "MiniMax",
+  "key_features": [
+    "MiniMax M1 text model with 1M token context window",
+    "Hailuo 02 video model for 1080p generation",
+    "Speech 02 model for high-quality speech synthesis and voice cloning",
+    "MCP server and toolkits for video, image, and speech workflows",
+    "AI-native applications: MiniMax Chat, MiniMax Agent, Hailuo Video, MiniMax Audio, Talkie"
+  ],
+  "supported_models": [
+    "MiniMax M1 (Text)",
+    "MiniMax Hailuo 02 (Video)",
+    "MiniMax Speech 02 (Audio)"
+  ],
+  "pricing_model": "MiniMax M1 from $0.4 per 1M input tokens; Speech-02-HD from $100 per 1M characters; Hailuo 02 video from $0.28 per video",
+  "benchmarks": {
+    "swe_bench_score": null,
+    "task_success_rate": null,
+    "resource_usage": "No public benchmarks found"
+  }
+}

--- a/agents/minimax_agent/profile.md
+++ b/agents/minimax_agent/profile.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Minimax Agent is part of the MiniMax platform, providing multimodal AI capabilities for text, audio, and video generation. It leverages large context windows and specialized models to build autonomous applications and creative experiences.
+Minimax Agent is part of the MiniMax platform, delivering multimodal AI for text, audio, and video generation. It leverages long context windows and specialized models to help developers build autonomous applications and creative media workflows.
 
 ## Key Information
 
@@ -12,11 +12,11 @@ Minimax Agent is part of the MiniMax platform, providing multimodal AI capabilit
 
 ## Key Features
 
-- MiniMax M1 text model with 1 million token input window
+- MiniMax M1 text model with 1 million token context window
 - Hailuo 02 video model for 1080p generation
 - Speech 02 model for high-quality speech synthesis and voice cloning
 - MCP server and toolkits for video, image, and speech workflows
-- Suite of AI-native applications such as MiniMax Chat and Talkie
+- Suite of AI-native applications including MiniMax Chat, MiniMax Agent, Hailuo Video, MiniMax Audio, and Talkie
 
 ## Supported Models
 
@@ -24,11 +24,17 @@ Minimax Agent is part of the MiniMax platform, providing multimodal AI capabilit
 - MiniMax Hailuo 02 (Video)
 - MiniMax Speech 02 (Audio)
 
+## Pricing
+
+- **MiniMax M1 (text):** Starts at $0.4 per 1M input tokens
+- **Speech-02-HD (audio):** $100 per 1M characters
+- **MiniMax Hailuo 02 (video):** Starting from $0.28 per video
+
 ## Benchmarks
 
-- **SWE-bench score:** No published results
+- **SWE-bench score:** Not available
 - **Task Success Rate:** Not publicly reported
-- **Resource Usage:** No public benchmarks available
+- **Resource Usage:** No public benchmarks found
 
 ## Qualitative Assessment
 


### PR DESCRIPTION
## Summary
- Add comprehensive profile for Minimax Agent outlining features, supported models, pricing, and qualitative assessment.
- Introduce agent_minimax_agent.json capturing metadata and benchmarks.

## Testing
- `pytest` (no tests found)

------
https://chatgpt.com/codex/tasks/task_e_689c57f019008321a3ed9889f92aacb8