### PR TITLE
Update Android Studio Bot documentation and persona ratings

### DIFF
--- a/agents/Android_Studio_Bot/agent_Android_Studio_Bot.json
+++ b/agents/Android_Studio_Bot/agent_Android_Studio_Bot.json
@@ -3,19 +3,23 @@
   "website": "https://developer.android.com/studio",
   "developer": "Google",
   "key_features": [
-    "AI-powered conversational experience",
-    "Generates code",
-    "Answers questions about Android development",
-    "Helps fix errors",
-    "Leverages Codey, Google's foundation model for coding, which is a descendant of PaLM 2."
+    "Conversational assistant integrated into Android Studio",
+    "Context-aware Kotlin and Java code generation",
+    "Answers Android development questions with links to official documentation",
+    "Suggests fixes for build and runtime errors",
+    "Generates unit tests and Jetpack Compose UI snippets",
+    "Explains existing code and APIs"
   ],
   "supported_models": [
-    "Codey (descendant of PaLM 2)"
+    "Gemini (fine-tuned for Android development; initially Codey based on PaLM 2)"
   ],
   "pricing_model": "Included with Android Studio",
   "benchmarks": {
     "swe_bench_score": null,
+    "swe_bench_source": null,
+    "terminal_bench_score": null,
+    "terminal_bench_source": null,
     "task_success_rate": null,
-    "resource_usage": ""
+    "resource_usage": null
   }
 }

--- a/agents/Android_Studio_Bot/persona_ratings_android_studio_bot.json
+++ b/agents/Android_Studio_Bot/persona_ratings_android_studio_bot.json
@@ -1,34 +1,34 @@
 {
   "automation_productivity": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "Provides code generation and error-fix suggestions inside Android Studio, speeding up routine development tasks, but it does not yet handle end-to-end automation or project management."
   },
   "beginner_friendly_onboarding": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 4,
+    "reasoning": "Activation is a simple opt-in within Android Studio and the feature is backed by detailed guides and codelabs, though availability is limited to certain regions."
   },
   "code_quality_testing": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "Can propose fixes and generate unit tests for Kotlin and Java, but developers still need to run tests and review results manually."
   },
   "codebase_comprehension": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "Uses project context to explain code and APIs, yet its understanding is limited to files that are open or indexed in the IDE."
   },
   "creative_multimodal_exploration": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 1,
+    "reasoning": "Interaction is text-only with no support for image, audio, or other modalities."
   },
   "data_experimental_flexibility": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "Focuses on Android project code and lacks native tools for arbitrary data analysis or custom data connections."
   },
   "visual_no_code_development": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 1,
+    "reasoning": "Designed for code-centric workflows rather than drag-and-drop or no-code development."
   },
   "workflow_agent_orchestration": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "Acts as a single assistant within the IDE and does not coordinate multiple agents or automate deployments."
   }
 }

--- a/agents/Android_Studio_Bot/profile.md
+++ b/agents/Android_Studio_Bot/profile.md
@@ -2,41 +2,43 @@
 
 ## Overview
 
-Android Studio Bot is an AI-powered conversational experience integrated into Android Studio. It is designed to make Android developers more productive by helping them generate code, answer questions, and fix errors.
+Android Studio Bot, also branded as Gemini in Android Studio, is a conversational AI assistant built into Android Studio. Introduced at Google I/O 2023 and upgraded to Gemini models in 2024, it helps Android developers generate code, answer questions, and resolve errors within the IDE.
 
 ## Key Information
 
 - **Developer:** Google
 - **Website:** [https://developer.android.com/studio](https://developer.android.com/studio)
+- **Release:** Preview announced May 2023; Gemini update rolled out with Android Studio Koala in 2024
 - **Pricing:** Included with Android Studio
 
 ## Key Features
 
-- **AI-powered conversational experience:** Chat with Studio Bot to get help with your code.
-- **Code generation:** Generate code for your app.
-- **Q&A:** Ask questions about Android development.
-- **Error fixing:** Get help with fixing errors in your code.
+- Conversational assistant embedded directly in Android Studio
+- Context-aware Kotlin and Java code generation
+- Explains APIs, best practices, and Android concepts
+- Suggests fixes for build and runtime errors with links to docs
+- Generates unit tests and Jetpack Compose UI snippets
 
 ## Supported Models
 
-- Codey (descendant of PaLM 2)
+- Gemini models fine-tuned for Android development (initially Codey, a PaLM 2 descendant)
 
 ## Benchmarks
 
-- **SWE-bench score:** Not available
-- **Task Success Rate:** Not available
-- **Resource Usage:** Not available
+- **SWE-bench score:** Not publicly reported
+- **Task Success Rate:** Not publicly reported
+- **Resource Usage:** Not publicly reported
 
 ## Qualitative Assessment
 
-- **Ease of Use:** High
-- **Documentation Quality:** High
-- **Onboarding Experience:** Straightforward
+- **Ease of Use:** High – accessed through the Gemini chat panel after signing in
+- **Documentation Quality:** High – official developer guides and in-IDE tips
+- **Onboarding Experience:** Straightforward – enable from `Tools > Gemini > Enable` and start conversing
 
 ## Pricing
 
-Android Studio Bot is a free feature integrated into Android Studio.
+Android Studio Bot is included at no additional cost for users of Android Studio.
 
 ## Getting Started
 
-To get started with Android Studio Bot, you can download the latest version of Android Studio and enable the feature in the settings. For more information, you can refer to the [official announcement blog post](https://android-developers.googleblog.com/2023/05/android-studio-io-23-announcing-studio-bot.html).
+Install the latest version of Android Studio, sign in with a Google account, and enable the Gemini or Studio Bot feature from the IDE settings to begin chatting.


### PR DESCRIPTION
## Summary
- expand Android Studio Bot profile with release timeline, Gemini model support, and richer feature list
- document capabilities in agent JSON including context-aware code generation and test creation
- add researched persona ratings with detailed reasoning

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c5b09db8883219c09343f0bc8d9bd