### PR TITLE
Configure Tailwind with style guide colors and fonts

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.cdnfonts.com/css/archia" rel="stylesheet" />
     <title>AI Agent Research</title>
   </head>
   <body>

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply font-sans;
+  }
+}

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -2,7 +2,18 @@
 export default {
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'background-blue': '#142ED9',
+        'stratos-blue': '#151975',
+        'sparky-blue': '#00ebff',
+        'highlight-green': '#9FDB9D',
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+        archia: ['Archia', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- integrate Inter and Archia fonts via HTML links and Tailwind theme
- add custom color palette from style guide to Tailwind config
- set base font to new sans family

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d1727140c8321ac0117687c9bf3af