### PR TITLE
feat: add agent detail modal

### DIFF
--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -1,17 +1,30 @@
+import { useState } from "react";
 import AgentTable from "./components/AgentTable";
+import AgentDetailModal from "./components/AgentDetailModal";
 
 function App() {
+  const [selectedAgent, setSelectedAgent] = useState(null);
+
+  const handleAgentClick = (agent) => {
+    setSelectedAgent(agent);
+  };
+
+  const handleCloseModal = () => {
+    setSelectedAgent(null);
+  };
+
   return (
     <div className="min-h-screen flex flex-col">
       <header className="bg-gray-100 p-4">
         <h1 className="text-2xl font-bold text-stratos-blue">AI Agent Research</h1>
       </header>
       <main className="flex-grow p-4">
-        <AgentTable />
+        <AgentTable onAgentClick={handleAgentClick} />
       </main>
       <footer className="bg-gray-100 p-4 text-center">
         <p className="text-stratos-blue">&copy; 2024 AI Agent Research</p>
       </footer>
+      <AgentDetailModal agent={selectedAgent} onClose={handleCloseModal} />
     </div>
   );
 }

--- a/website/src/components/AgentDetailModal.jsx
+++ b/website/src/components/AgentDetailModal.jsx
@@ -1,0 +1,57 @@
+function AgentDetailModal({ agent, onClose }) {
+  if (!agent) return null;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+      <div className="bg-background-blue text-white p-6 rounded-md shadow-lg max-w-lg w-full overflow-y-auto max-h-full">
+        <div className="flex justify-between items-start mb-4">
+          <h2 className="text-2xl font-archia">{agent.name}</h2>
+          <button
+            onClick={onClose}
+            className="text-white hover:text-sparky-blue"
+            aria-label="Close"
+          >
+            &times;
+          </button>
+        </div>
+        <p className="mb-2"><span className="font-archia">Developer:</span> {agent.developer}</p>
+        <p className="mb-4"><span className="font-archia">Pricing:</span> {agent.pricing_model}</p>
+        <div className="mb-4">
+          <h3 className="font-archia mb-1">Key Features:</h3>
+          <ul className="list-disc list-inside text-sm space-y-1">
+            {agent.key_features?.map((feature, index) => (
+              <li key={index}>{feature}</li>
+            ))}
+          </ul>
+        </div>
+        <div className="mb-4">
+          <h3 className="font-archia mb-1">Supported Models:</h3>
+          <ul className="list-disc list-inside text-sm space-y-1">
+            {agent.supported_models?.map((model, index) => (
+              <li key={index}>{model}</li>
+            ))}
+          </ul>
+        </div>
+        <div className="text-right">
+          <a
+            href={agent.website}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block bg-sparky-blue text-stratos-blue px-4 py-2 rounded font-archia mr-2"
+          >
+            Visit Website
+          </a>
+          <button
+            onClick={onClose}
+            className="bg-sparky-blue text-stratos-blue px-4 py-2 rounded font-archia"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AgentDetailModal;
+

--- a/website/src/components/AgentTable.jsx
+++ b/website/src/components/AgentTable.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-function AgentTable() {
+function AgentTable({ onAgentClick }) {
   const [agents, setAgents] = useState([]);
 
   useEffect(() => {
@@ -33,7 +33,15 @@ function AgentTable() {
         <tbody>
           {agents.map((agent) => (
             <tr key={agent.name} className="odd:bg-white even:bg-background-blue/10">
-              <td className="px-4 py-2"><a href={agent.website} className="underline" target="_blank" rel="noopener noreferrer">{agent.name}</a></td>
+              <td className="px-4 py-2">
+                <button
+                  type="button"
+                  onClick={() => onAgentClick(agent)}
+                  className="underline text-left"
+                >
+                  {agent.name}
+                </button>
+              </td>
               <td className="px-4 py-2">{agent.developer}</td>
               <td className="px-4 py-2">{agent.pricing_model}</td>
             </tr>


### PR DESCRIPTION
## Summary
- add responsive `AgentDetailModal` component to show agent details
- open agent detail modal when clicking a name in `AgentTable`
- manage modal state in `App`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d220bc66483218a30e4f3e863f40c