### PR TITLE
Add persona detail page with routing

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -1101,6 +1102,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3331,6 +3341,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
-import AgentTable from "./components/AgentTable";
+import { Routes, Route } from "react-router-dom";
 import AgentDetailModal from "./components/AgentDetailModal";
 import PersonasOverlay from "./components/PersonasOverlay";
+import Home from "./pages/Home";
+import PersonaDetail from "./pages/PersonaDetail";
 
 function App() {
   const [selectedAgent, setSelectedAgent] = useState(null);
@@ -29,16 +31,21 @@ function App() {
         <h1 className="text-2xl font-bold text-stratos-blue">AI Agent Research</h1>
       </header>
       <main className="flex-grow p-4">
-        <div className="mb-4">
-          <button
-            type="button"
-            onClick={handleOpenPersonas}
-            className="bg-stratos-blue text-white px-4 py-2 rounded font-archia"
-          >
-            Can you recommend something?
-          </button>
-        </div>
-        <AgentTable onAgentClick={handleAgentClick} />
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <Home
+                onAgentClick={handleAgentClick}
+                onOpenPersonas={handleOpenPersonas}
+              />
+            }
+          />
+          <Route
+            path="/personas/:id"
+            element={<PersonaDetail onAgentClick={handleAgentClick} />}
+          />
+        </Routes>
       </main>
       <footer className="bg-gray-100 p-4 text-center">
         <p className="text-stratos-blue">&copy; 2024 AI Agent Research</p>

--- a/website/src/components/AgentTable.jsx
+++ b/website/src/components/AgentTable.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-function AgentTable({ onAgentClick }) {
+function AgentTable({ onAgentClick, filterNames }) {
   const [agents, setAgents] = useState([]);
 
   useEffect(() => {
@@ -20,6 +20,14 @@ function AgentTable({ onAgentClick }) {
     loadAgents();
   }, []);
 
+  const displayedAgents = filterNames
+    ? agents.filter(
+        (a) =>
+          filterNames.includes(a.name) ||
+          filterNames.includes(a.name.replace(/\s+/g, '_'))
+      )
+    : agents;
+
   return (
     <div className="overflow-x-auto">
       <table className="min-w-full text-sm text-stratos-blue border border-background-blue">
@@ -31,7 +39,7 @@ function AgentTable({ onAgentClick }) {
           </tr>
         </thead>
         <tbody>
-          {agents.map((agent) => (
+          {displayedAgents.map((agent) => (
             <tr key={agent.name} className="odd:bg-white even:bg-background-blue/10">
               <td className="px-4 py-2">
                 <button

--- a/website/src/components/PersonasOverlay.jsx
+++ b/website/src/components/PersonasOverlay.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 
 function PersonasOverlay({ isOpen, onClose }) {
   const [personas, setPersonas] = useState([]);
@@ -45,10 +46,15 @@ function PersonasOverlay({ isOpen, onClose }) {
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {personas.map((persona) => (
-            <div key={persona.id} className="bg-sparky-blue text-background-blue p-4 rounded">
+            <Link
+              key={persona.id}
+              to={`/personas/${persona.id}`}
+              onClick={onClose}
+              className="bg-sparky-blue text-background-blue p-4 rounded"
+            >
               <h3 className="font-archia text-lg mb-2">{persona.title}</h3>
               <p className="text-sm">{persona.description}</p>
-            </div>
+            </Link>
           ))}
         </div>
       </div>

--- a/website/src/main.jsx
+++ b/website/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/website/src/pages/Home.jsx
+++ b/website/src/pages/Home.jsx
@@ -1,0 +1,20 @@
+import AgentTable from "../components/AgentTable";
+
+function Home({ onAgentClick, onOpenPersonas }) {
+  return (
+    <div>
+      <div className="mb-4">
+        <button
+          type="button"
+          onClick={onOpenPersonas}
+          className="bg-stratos-blue text-white px-4 py-2 rounded font-archia"
+        >
+          Can you recommend something?
+        </button>
+      </div>
+      <AgentTable onAgentClick={onAgentClick} />
+    </div>
+  );
+}
+
+export default Home;

--- a/website/src/pages/PersonaDetail.jsx
+++ b/website/src/pages/PersonaDetail.jsx
@@ -1,0 +1,96 @@
+import { useParams, Link } from "react-router-dom";
+import { useEffect, useState } from "react";
+import AgentTable from "../components/AgentTable";
+
+function PersonaDetail({ onAgentClick }) {
+  const { id } = useParams();
+  const [persona, setPersona] = useState(null);
+  const [recommendedAgents, setRecommendedAgents] = useState([]);
+
+  useEffect(() => {
+    async function loadPersona() {
+      try {
+        const res = await fetch('/personas.json');
+        if (!res.ok) {
+          throw new Error('Failed to fetch persona data');
+        }
+        const data = await res.json();
+        const content = data[id];
+        if (!content) return;
+
+        const keyCriteriaStart = content.indexOf('### Key Criteria');
+        const recommendedStart = content.indexOf('## Recommended Tools');
+        const whyStart = content.indexOf('## Why These Tools');
+
+        const title = content.substring(0, content.indexOf('\n')).replace(/^#\s*/, '');
+        const description = content.substring(content.indexOf('\n') + 2, keyCriteriaStart).trim();
+
+        const keyCriteriaText = content.substring(keyCriteriaStart, recommendedStart).trim();
+        const keyCriteria = keyCriteriaText
+          .split('\n')
+          .slice(1)
+          .filter((l) => l.startsWith('-'))
+          .map((l) => l.replace(/^-\s*/, ''));
+
+        const recommendedText = content.substring(recommendedStart, whyStart).trim();
+        const recommendedLines = recommendedText
+          .split('\n')
+          .slice(1)
+          .filter((l) => l.startsWith('-'))
+          .map((l) => l.replace(/^-\s*/, ''));
+        const recommendedNames = recommendedLines.map((line) => {
+          const match = line.match(/\*\*(.+?)\*\*/);
+          return match ? match[1] : line;
+        });
+
+        const whyText = content.substring(whyStart).trim();
+        const whyLines = whyText
+          .split('\n')
+          .slice(1)
+          .filter((l) => l.startsWith('-'))
+          .map((l) => l.replace(/^-\s*/, ''));
+
+        setPersona({ title, description, keyCriteria, recommendedLines, whyLines });
+        setRecommendedAgents(recommendedNames);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    loadPersona();
+  }, [id]);
+
+  if (!persona) {
+    return <div className="text-stratos-blue">Loading...</div>;
+  }
+
+  return (
+    <div className="text-stratos-blue">
+      <Link to="/" className="underline">&larr; Back</Link>
+      <h2 className="text-2xl font-archia mb-4">{persona.title}</h2>
+      <p className="mb-4">{persona.description}</p>
+      <h3 className="text-xl font-archia mb-2">Key Criteria</h3>
+      <ul className="list-disc pl-5 mb-4">
+        {persona.keyCriteria.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+      <h3 className="text-xl font-archia mb-2">Recommended Tools</h3>
+      <ul className="list-disc pl-5 mb-4">
+        {persona.recommendedLines.map((line) => (
+          <li key={line}>{line}</li>
+        ))}
+      </ul>
+      <h3 className="text-xl font-archia mb-2">Why These Tools</h3>
+      <ul className="list-disc pl-5 mb-4">
+        {persona.whyLines.map((line) => (
+          <li key={line}>{line}</li>
+        ))}
+      </ul>
+      <h3 className="text-xl font-archia mb-2">Recommended Agents</h3>
+      <AgentTable onAgentClick={onAgentClick} filterNames={recommendedAgents} />
+    </div>
+  );
+}
+
+export default PersonaDetail;


### PR DESCRIPTION
## Summary
- add react-router and wrap app with `<BrowserRouter>`
- implement persona detail page with recommended agents
- link persona cards to new detail pages and filter agent table

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d833a47248321a7bfbca260bbb935