### PR TITLE
feat: add sorting and search to agent table

### DIFF
--- a/website/src/components/AgentTable.jsx
+++ b/website/src/components/AgentTable.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 
-function AgentTable({ onAgentClick, filterNames }) {
+function AgentTable({ onAgentClick, filterNames, searchTerm = "" }) {
   const [agents, setAgents] = useState([]);
+  const [sortConfig, setSortConfig] = useState({ key: null, direction: "asc" });
 
   useEffect(() => {
     async function loadAgents() {
@@ -20,7 +21,7 @@ function AgentTable({ onAgentClick, filterNames }) {
     loadAgents();
   }, []);
 
-  const displayedAgents = filterNames
+  const filteredByNames = filterNames
     ? agents.filter(
         (a) =>
           filterNames.includes(a.name) ||
@@ -28,18 +29,61 @@ function AgentTable({ onAgentClick, filterNames }) {
       )
     : agents;
 
+  const filteredAgents = searchTerm
+    ? filteredByNames.filter((a) =>
+        a.name.toLowerCase().includes(searchTerm.toLowerCase())
+      )
+    : filteredByNames;
+
+  const sortedAgents = sortConfig.key
+    ? [...filteredAgents].sort((a, b) => {
+        const aValue = a[sortConfig.key] || "";
+        const bValue = b[sortConfig.key] || "";
+        if (aValue < bValue) {
+          return sortConfig.direction === "asc" ? -1 : 1;
+        }
+        if (aValue > bValue) {
+          return sortConfig.direction === "asc" ? 1 : -1;
+        }
+        return 0;
+      })
+    : filteredAgents;
+
+  const handleSort = (key) => {
+    setSortConfig((prev) => ({
+      key,
+      direction:
+        prev.key === key && prev.direction === "asc" ? "desc" : "asc",
+    }));
+  };
+
   return (
     <div className="overflow-x-auto">
       <table className="min-w-full text-sm text-stratos-blue border border-background-blue">
         <thead className="bg-background-blue text-white">
           <tr>
-            <th className="px-4 py-2 font-archia">Name</th>
-            <th className="px-4 py-2 font-archia">Developer</th>
-            <th className="px-4 py-2 font-archia">Pricing</th>
+            <th
+              className="px-4 py-2 font-archia cursor-pointer"
+              onClick={() => handleSort("name")}
+            >
+              Name
+            </th>
+            <th
+              className="px-4 py-2 font-archia cursor-pointer"
+              onClick={() => handleSort("developer")}
+            >
+              Developer
+            </th>
+            <th
+              className="px-4 py-2 font-archia cursor-pointer"
+              onClick={() => handleSort("pricing_model")}
+            >
+              Pricing
+            </th>
           </tr>
         </thead>
         <tbody>
-          {displayedAgents.map((agent) => (
+          {sortedAgents.map((agent) => (
             <tr key={agent.name} className="odd:bg-white even:bg-background-blue/10">
               <td className="px-4 py-2">
                 <button

--- a/website/src/pages/Home.jsx
+++ b/website/src/pages/Home.jsx
@@ -1,9 +1,12 @@
+import { useState } from "react";
 import AgentTable from "../components/AgentTable";
 
 function Home({ onAgentClick, onOpenPersonas }) {
+  const [searchTerm, setSearchTerm] = useState("");
+
   return (
     <div>
-      <div className="mb-4">
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center">
         <button
           type="button"
           onClick={onOpenPersonas}
@@ -11,8 +14,15 @@ function Home({ onAgentClick, onOpenPersonas }) {
         >
           Can you recommend something?
         </button>
+        <input
+          type="text"
+          placeholder="Search agents..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="border px-2 py-1 rounded font-archia text-stratos-blue"
+        />
       </div>
-      <AgentTable onAgentClick={onAgentClick} />
+      <AgentTable onAgentClick={onAgentClick} searchTerm={searchTerm} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enable sortable columns and name filtering for agent table
- add search bar on the home page to filter agents by name

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d8537919c8321a9edef677d31b3fa