### PR TITLE
Make agent detail modal responsive and reposition visit website

### DIFF
--- a/website/src/components/AgentDetailModal.jsx
+++ b/website/src/components/AgentDetailModal.jsx
@@ -46,7 +46,7 @@ function AgentDetailModal({ agent, onClose }) {
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
-      <div className="bg-background-blue text-white p-6 rounded-md shadow-lg max-w-lg w-full overflow-y-auto max-h-full">
+      <div className="bg-background-blue text-white p-6 rounded-md shadow-lg w-[90vw] max-h-full overflow-y-auto">
         <div className="flex justify-between items-start mb-4">
           <h2 className="text-2xl font-archia">{agent.name}</h2>
           <button
@@ -58,7 +58,17 @@ function AgentDetailModal({ agent, onClose }) {
           </button>
         </div>
         <p className="mb-2"><span className="font-archia">Developer:</span> {agent.developer}</p>
-        <p className="mb-4"><span className="font-archia">Pricing:</span> {agent.pricing_model}</p>
+        <p className="mb-2"><span className="font-archia">Pricing:</span> {agent.pricing_model}</p>
+        <div className="mb-4">
+          <a
+            href={agent.website}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block bg-sparky-blue text-stratos-blue px-4 py-2 rounded font-archia"
+          >
+            Visit Website
+          </a>
+        </div>
         <div className="mb-4">
           <h3 className="font-archia mb-1">Key Features:</h3>
           <ul className="list-disc list-inside text-sm space-y-1">
@@ -93,14 +103,6 @@ function AgentDetailModal({ agent, onClose }) {
           </ul>
         </div>
         <div className="text-right">
-          <a
-            href={agent.website}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-block bg-sparky-blue text-stratos-blue px-4 py-2 rounded font-archia mr-2"
-          >
-            Visit Website
-          </a>
           <button
             onClick={onClose}
             className="bg-sparky-blue text-stratos-blue px-4 py-2 rounded font-archia"


### PR DESCRIPTION
## Summary
- Make agent detail modal responsive at 90% viewport width.
- Move Visit Website button between Pricing and Key Features.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d9c1d66f8832185fd096e0c279f99