### PR TITLE
Fix persona ratings lookup in agent table

### DIFF
--- a/website/src/components/AgentTable.jsx
+++ b/website/src/components/AgentTable.jsx
@@ -68,6 +68,9 @@ function AgentTable({ onAgentClick, filterNames, searchTerm = "" }) {
     return filled + empty;
   };
 
+  const getAgentKey = (name) =>
+    name?.toLowerCase().replace(/\s+/g, "_");
+
   const handleSort = (key) => {
     setSortConfig((prev) => ({
       key,
@@ -122,7 +125,9 @@ function AgentTable({ onAgentClick, filterNames, searchTerm = "" }) {
               <td className="px-4 py-2">{agent.pricing_model}</td>
               {criteria.map((c) => (
                 <td key={c.id} className="px-2 py-2 text-center">
-                  {renderStars(ratings[agent.name]?.[c.id]?.rating)}
+                  {renderStars(
+                    ratings[getAgentKey(agent.name)]?.[c.id]?.rating
+                  )}
                 </td>
               ))}
             </tr>


### PR DESCRIPTION
## Summary
- Ensure agent persona ratings display by slugifying names before lookup in the agent table

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d9c62ccf48321a5218a6eebbc3e5a