### PR TITLE
Refine persona detail layout and agent sorting

### DIFF
--- a/website/src/components/AgentTable.jsx
+++ b/website/src/components/AgentTable.jsx
@@ -34,11 +34,14 @@ function AgentTable({ onAgentClick, filterNames, searchTerm = "" }) {
   }, []);
 
   const filteredByNames = filterNames
-    ? agents.filter(
-        (a) =>
-          filterNames.includes(a.name) ||
-          filterNames.includes(a.name.replace(/\s+/g, '_'))
-      )
+    ? filterNames
+        .map((name) =>
+          agents.find(
+            (a) =>
+              a.name === name || a.name.replace(/\s+/g, '_') === name
+          )
+        )
+        .filter(Boolean)
     : agents;
 
   const filteredAgents = searchTerm

--- a/website/src/pages/PersonaDetail.jsx
+++ b/website/src/pages/PersonaDetail.jsx
@@ -7,37 +7,57 @@ function PersonaDetail({ onAgentClick }) {
   const [persona, setPersona] = useState(null);
   const [recommendedAgents, setRecommendedAgents] = useState([]);
 
+  const renderMarkdown = (text) => ({
+    __html: text.replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>"),
+  });
+
   useEffect(() => {
     async function loadPersona() {
       try {
-        const res = await fetch('/personas.json');
-        if (!res.ok) {
-          throw new Error('Failed to fetch persona data');
+        const [personaRes, criteriaRes, ratingsRes] = await Promise.all([
+          fetch("/personas.json"),
+          fetch("/persona_criteria.json"),
+          fetch("/persona_ratings.json"),
+        ]);
+        if (!personaRes.ok || !criteriaRes.ok || !ratingsRes.ok) {
+          throw new Error("Failed to fetch persona data");
         }
-        const data = await res.json();
+        const [data, criteriaData, ratingsData] = await Promise.all([
+          personaRes.json(),
+          criteriaRes.json(),
+          ratingsRes.json(),
+        ]);
         const content = data[id];
         if (!content) return;
 
-        const keyCriteriaStart = content.indexOf('### Key Criteria');
-        const recommendedStart = content.indexOf('## Recommended Tools');
-        const whyStart = content.indexOf('## Why These Tools');
+        const keyCriteriaStart = content.indexOf("### Key Criteria");
+        const recommendedStart = content.indexOf("## Recommended Tools");
+        const whyStart = content.indexOf("## Why These Tools");
 
-        const title = content.substring(0, content.indexOf('\n')).replace(/^#\s*/, '');
-        const description = content.substring(content.indexOf('\n') + 2, keyCriteriaStart).trim();
+        const title = content
+          .substring(0, content.indexOf("\n"))
+          .replace(/^#\s*/, "");
+        const description = content
+          .substring(content.indexOf("\n") + 2, keyCriteriaStart)
+          .trim();
 
-        const keyCriteriaText = content.substring(keyCriteriaStart, recommendedStart).trim();
+        const keyCriteriaText = content
+          .substring(keyCriteriaStart, recommendedStart)
+          .trim();
         const keyCriteria = keyCriteriaText
-          .split('\n')
+          .split("\n")
           .slice(1)
-          .filter((l) => l.startsWith('-'))
-          .map((l) => l.replace(/^-\s*/, ''));
+          .filter((l) => l.startsWith("-"))
+          .map((l) => l.replace(/^-\s*/, ""));
 
-        const recommendedText = content.substring(recommendedStart, whyStart).trim();
+        const recommendedText = content
+          .substring(recommendedStart, whyStart)
+          .trim();
         const recommendedLines = recommendedText
-          .split('\n')
+          .split("\n")
           .slice(1)
-          .filter((l) => l.startsWith('-'))
-          .map((l) => l.replace(/^-\s*/, ''));
+          .filter((l) => l.startsWith("-"))
+          .map((l) => l.replace(/^-\s*/, ""));
         const recommendedNames = recommendedLines.map((line) => {
           const match = line.match(/\*\*(.+?)\*\*/);
           return match ? match[1] : line;
@@ -45,13 +65,38 @@ function PersonaDetail({ onAgentClick }) {
 
         const whyText = content.substring(whyStart).trim();
         const whyLines = whyText
-          .split('\n')
+          .split("\n")
           .slice(1)
-          .filter((l) => l.startsWith('-'))
-          .map((l) => l.replace(/^-\s*/, ''));
+          .filter((l) => l.startsWith("-"))
+          .map((l) => l.replace(/^-\s*/, ""));
 
-        setPersona({ title, description, keyCriteria, recommendedLines, whyLines });
-        setRecommendedAgents(recommendedNames);
+        const personaCriteriaIds = criteriaData
+          .filter((c) => c.personas.includes(title))
+          .map((c) => c.id);
+
+        const getAgentKey = (name) =>
+          name?.toLowerCase().replace(/\s+/g, "_");
+
+        const sortedNames = [...recommendedNames]
+          .sort((a, b) => {
+            const aAvg =
+              personaCriteriaIds.reduce(
+                (sum, id) =>
+                  sum + (ratingsData[getAgentKey(a)]?.[id]?.rating || 0),
+                0
+              ) / personaCriteriaIds.length;
+            const bAvg =
+              personaCriteriaIds.reduce(
+                (sum, id) =>
+                  sum + (ratingsData[getAgentKey(b)]?.[id]?.rating || 0),
+                0
+              ) / personaCriteriaIds.length;
+            return bAvg - aAvg;
+          })
+          .slice(0, 4);
+
+        setPersona({ title, description, keyCriteria, whyLines });
+        setRecommendedAgents(sortedNames);
       } catch (err) {
         console.error(err);
       }
@@ -66,27 +111,37 @@ function PersonaDetail({ onAgentClick }) {
 
   return (
     <div className="text-stratos-blue">
-      <Link to="/" className="underline">&larr; Back</Link>
-      <h2 className="text-2xl font-archia mb-4">{persona.title}</h2>
-      <p className="mb-4">{persona.description}</p>
-      <h3 className="text-xl font-archia mb-2">Key Criteria</h3>
-      <ul className="list-disc pl-5 mb-4">
-        {persona.keyCriteria.map((item) => (
-          <li key={item}>{item}</li>
-        ))}
-      </ul>
-      <h3 className="text-xl font-archia mb-2">Recommended Tools</h3>
-      <ul className="list-disc pl-5 mb-4">
-        {persona.recommendedLines.map((line) => (
-          <li key={line}>{line}</li>
-        ))}
-      </ul>
-      <h3 className="text-xl font-archia mb-2">Why These Tools</h3>
-      <ul className="list-disc pl-5 mb-4">
-        {persona.whyLines.map((line) => (
-          <li key={line}>{line}</li>
-        ))}
-      </ul>
+      <Link to="/" className="underline">
+        &larr; Back
+      </Link>
+      <div className="border border-background-blue p-4 mb-4">
+        <h2 className="text-2xl font-archia mb-2">{persona.title}</h2>
+        <p className="mb-0">{persona.description}</p>
+      </div>
+      <div className="flex flex-col md:flex-row gap-4 mb-4">
+        <div className="border border-background-blue p-4 flex-1">
+          <h3 className="text-xl font-archia mb-2">Key Criteria</h3>
+          <ul className="list-disc pl-5">
+            {persona.keyCriteria.map((item) => (
+              <li
+                key={item}
+                dangerouslySetInnerHTML={renderMarkdown(item)}
+              />
+            ))}
+          </ul>
+        </div>
+        <div className="border border-background-blue p-4 flex-1">
+          <h3 className="text-xl font-archia mb-2">Why These Tools</h3>
+          <ul className="list-disc pl-5">
+            {persona.whyLines.map((line) => (
+              <li
+                key={line}
+                dangerouslySetInnerHTML={renderMarkdown(line)}
+              />
+            ))}
+          </ul>
+        </div>
+      </div>
       <h3 className="text-xl font-archia mb-2">Recommended Agents</h3>
       <AgentTable onAgentClick={onAgentClick} filterNames={recommendedAgents} />
     </div>


### PR DESCRIPTION
## Summary
- fix markdown rendering for persona criteria and tool descriptions
- drop redundant recommended tools list and add boxed layout with persona info, criteria, and tool rationale
- sort recommended agents by average rating across persona criteria and preserve order in agent table

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d9e00228c8321924425ea19f752c7