### PR TITLE
feat: support multi-criteria agent sorting

### DIFF
--- a/website/src/components/AgentTable.jsx
+++ b/website/src/components/AgentTable.jsx
@@ -5,6 +5,7 @@ function AgentTable({ onAgentClick, filterNames, searchTerm = "" }) {
   const [sortConfig, setSortConfig] = useState({ key: null, direction: "asc" });
   const [ratings, setRatings] = useState({});
   const [criteria, setCriteria] = useState([]);
+  const [selectedCriteria, setSelectedCriteria] = useState([]);
 
   useEffect(() => {
     async function loadData() {
@@ -33,6 +34,21 @@ function AgentTable({ onAgentClick, filterNames, searchTerm = "" }) {
     loadData();
   }, []);
 
+  useEffect(() => {
+    setSortConfig((prev) => {
+      if (selectedCriteria.length > 0) {
+        return {
+          key: "_avg",
+          direction: prev.key === "_avg" ? prev.direction : "desc",
+        };
+      }
+      if (prev.key === "_avg") {
+        return { key: null, direction: "asc" };
+      }
+      return prev;
+    });
+  }, [selectedCriteria]);
+
   const filteredByNames = filterNames
     ? filterNames
         .map((name) =>
@@ -50,27 +66,6 @@ function AgentTable({ onAgentClick, filterNames, searchTerm = "" }) {
       )
     : filteredByNames;
 
-  const sortedAgents = sortConfig.key
-    ? [...filteredAgents].sort((a, b) => {
-        const aValue = a[sortConfig.key] || "";
-        const bValue = b[sortConfig.key] || "";
-        if (aValue < bValue) {
-          return sortConfig.direction === "asc" ? -1 : 1;
-        }
-        if (aValue > bValue) {
-          return sortConfig.direction === "asc" ? 1 : -1;
-        }
-        return 0;
-      })
-    : filteredAgents;
-
-  const renderStars = (rating) => {
-    if (!rating) return "☆☆☆☆☆";
-    const filled = "★".repeat(rating);
-    const empty = "☆".repeat(5 - rating);
-    return filled + empty;
-  };
-
   const getAgentKey = (name) => {
     if (!name) return "";
     const lower = name.toLowerCase();
@@ -81,12 +76,58 @@ function AgentTable({ onAgentClick, filterNames, searchTerm = "" }) {
     return candidates.find((k) => ratings[k]) || sanitized;
   };
 
+  const computeAverage = (agent) => {
+    const key = getAgentKey(agent.name);
+    const ratingsForAgent = selectedCriteria.map(
+      (id) => ratings[key]?.[id]?.rating || 0
+    );
+    if (ratingsForAgent.length === 0) return null;
+    return (
+      ratingsForAgent.reduce((sum, val) => sum + val, 0) /
+      ratingsForAgent.length
+    );
+  };
+
+  const agentsWithAverage = filteredAgents.map((a) => ({
+    ...a,
+    _avg: computeAverage(a),
+  }));
+
+  const sortedAgents = sortConfig.key
+    ? [...agentsWithAverage].sort((a, b) => {
+        const aValue =
+          sortConfig.key === "_avg" ? a._avg ?? -1 : a[sortConfig.key] || "";
+        const bValue =
+          sortConfig.key === "_avg" ? b._avg ?? -1 : b[sortConfig.key] || "";
+        if (aValue < bValue) {
+          return sortConfig.direction === "asc" ? -1 : 1;
+        }
+        if (aValue > bValue) {
+          return sortConfig.direction === "asc" ? 1 : -1;
+        }
+        return 0;
+      })
+    : agentsWithAverage;
+
+  const renderStars = (rating) => {
+    if (!rating) return "☆☆☆☆☆";
+    const filled = "★".repeat(rating);
+    const empty = "☆".repeat(5 - rating);
+    return filled + empty;
+  };
+
   const handleSort = (key) => {
     setSortConfig((prev) => ({
       key,
       direction:
         prev.key === key && prev.direction === "asc" ? "desc" : "asc",
     }));
+  };
+
+  const toggleCriterion = (id) => {
+    setSelectedCriteria((prev) =>
+      prev.includes(id) ? prev.filter((c) => c !== id) : [...prev, id]
+    );
   };
 
   return (
@@ -114,9 +155,31 @@ function AgentTable({ onAgentClick, filterNames, searchTerm = "" }) {
             </th>
             {criteria.map((c) => (
               <th key={c.id} className="px-2 py-2 font-archia">
-                {c.name}
+                <div className="flex items-center justify-center gap-1">
+                  <span
+                    className="cursor-pointer"
+                    onClick={() => handleSort("_avg")}
+                  >
+                    {c.name}
+                  </span>
+                  <button type="button" onClick={() => toggleCriterion(c.id)}>
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                      className={`w-3 h-3 ${
+                        selectedCriteria.includes(c.id)
+                          ? "text-white"
+                          : "text-white/50"
+                      }`}
+                    >
+                      <path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-.293.707L11 12.414V16a1 1 0 01-1.447.894L8 15v-2.586L3.293 6.707A1 1 0 013 6V4z" />
+                    </svg>
+                  </button>
+                </div>
               </th>
             ))}
+            <th className="hidden">Average</th>
           </tr>
         </thead>
         <tbody>
@@ -140,6 +203,9 @@ function AgentTable({ onAgentClick, filterNames, searchTerm = "" }) {
                   )}
                 </td>
               ))}
+              <td className="hidden">
+                {agent._avg !== null ? agent._avg.toFixed(2) : ""}
+              </td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- add multi-criteria sorting to AgentTable using average ratings
- enable criteria filter icons to include or exclude columns in sorting
- store hidden average column to reuse in persona detail pages
- ensure helper order so AgentTable loads without reference errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689de4a63e0c832183b94e9ce0c2f461