### PR TITLE
Add persona ratings for Replit AI

### DIFF
--- a/agents/Replit_AI/persona_ratings_replit_ai.json
+++ b/agents/Replit_AI/persona_ratings_replit_ai.json
@@ -1,34 +1,34 @@
 {
   "automation_productivity": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 4,
+    "reasoning": "Replit AI turns plain-English prompts into runnable apps and fixes bugs automatically, reducing manual coding work for rapid prototypes. [1]"
   },
   "beginner_friendly_onboarding": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 5,
+    "reasoning": "Designed for non-technical creators, Replit AI runs in the browser with a free tier and requires no local setup or coding experience. [1]"
   },
   "code_quality_testing": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "The agent can correct errors in code, and Replit's environment lets users run tests, but it lacks dedicated QA workflows. [1]"
   },
   "codebase_comprehension": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "Replit AI focuses on generating new projects rather than understanding or navigating large existing repositories. [2]"
   },
   "creative_multimodal_exploration": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "It can build apps from textual prompts and even from screenshots, offering basic multimodal creativity. [1]"
   },
   "data_experimental_flexibility": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "Users can experiment with code and data in Replit's cloud IDE, though the agent isn't specialized for data science workflows. [1]"
   },
   "visual_no_code_development": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "While no coding is required, interaction is via chat rather than a drag-and-drop builder, limiting visual development. [1]"
   },
   "workflow_agent_orchestration": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "Replit AI operates as a single agent within the IDE and doesn't coordinate multiple tools or agents. [2]"
   }
 }

--- a/website/public/persona_ratings.json
+++ b/website/public/persona_ratings.json
@@ -1191,36 +1191,36 @@
   },
   "replit_ai": {
     "automation_productivity": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 4,
+      "reasoning": "Replit AI turns plain-English prompts into runnable apps and fixes bugs automatically, reducing manual coding work for rapid prototypes. [1]"
     },
     "beginner_friendly_onboarding": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 5,
+      "reasoning": "Designed for non-technical creators, Replit AI runs in the browser with a free tier and requires no local setup or coding experience. [1]"
     },
     "code_quality_testing": {
       "rating": 3,
-      "reasoning": "Research to be done."
+      "reasoning": "The agent can correct errors in code, and Replit's environment lets users run tests, but it lacks dedicated QA workflows. [1]"
     },
     "codebase_comprehension": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 2,
+      "reasoning": "Replit AI focuses on generating new projects rather than understanding or navigating large existing repositories. [2]"
     },
     "creative_multimodal_exploration": {
       "rating": 3,
-      "reasoning": "Research to be done."
+      "reasoning": "It can build apps from textual prompts and even from screenshots, offering basic multimodal creativity. [1]"
     },
     "data_experimental_flexibility": {
       "rating": 3,
-      "reasoning": "Research to be done."
+      "reasoning": "Users can experiment with code and data in Replit's cloud IDE, though the agent isn't specialized for data science workflows. [1]"
     },
     "visual_no_code_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 2,
+      "reasoning": "While no coding is required, interaction is via chat rather than a drag-and-drop builder, limiting visual development. [1]"
     },
     "workflow_agent_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 2,
+      "reasoning": "Replit AI operates as a single agent within the IDE and doesn't coordinate multiple tools or agents. [2]"
     }
   },
   "roo_code": {


### PR DESCRIPTION
## Summary
- add research-backed persona ratings for Replit AI across automation, onboarding, quality, comprehension, creativity, data work, no-code, and orchestration
- propagate Replit AI ratings to website persona dataset

## Testing
- `npm test` (no tests defined)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e01a9ae1083218bca9a5eaba001bc