### PR TITLE
Add detailed Devin profile and persona ratings

### DIFF
--- a/agents/devin/persona_ratings_devin.json
+++ b/agents/devin/persona_ratings_devin.json
@@ -1,34 +1,34 @@
 {
   "automation_productivity": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 5,
+    "reasoning": "Devin autonomously plans and executes complex software projects, handling coding, testing, and deployment with minimal oversight."
   },
   "beginner_friendly_onboarding": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "The platform targets professional engineers and is available through a waitlisted beta, so newcomers face a steep learning curve."
   },
   "code_quality_testing": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 4,
+    "reasoning": "It runs unit tests, debugs failures, and fixes issues, but there is no emphasis on automated test generation."
   },
   "codebase_comprehension": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 5,
+    "reasoning": "Devin can onboard itself to unfamiliar repositories, read documentation, and fix bugs across large codebases."
   },
   "creative_multimodal_exploration": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 1,
+    "reasoning": "The agent focuses on software engineering tasks and does not offer multimodal creativity features."
   },
   "data_experimental_flexibility": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "Devin can work with various tools and frameworks inside its environment, yet it is not specialized for data science experimentation."
   },
   "visual_no_code_development": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 1,
+    "reasoning": "Interaction is code-centric; there are no drag-and-drop or no-code interfaces."
   },
   "workflow_agent_orchestration": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "Devin executes tasks end-to-end as a single agent but lacks tools for orchestrating multiple agents or pipelines."
   }
 }

--- a/agents/devin/profile.md
+++ b/agents/devin/profile.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Devin is the world's first fully autonomous AI software engineer, created by Cognition. It is designed to be a tireless, skilled teammate that can work alongside human engineers or independently complete tasks.
+Devin is the world's first fully autonomous AI software engineer, created by Cognition. It is designed to be a tireless, skilled teammate that can work alongside human engineers or independently complete tasks. Operating inside a complete development environment with a shell, code editor, and browser, Devin can plan, build, and deploy software projects end to end. It reads documentation to learn new frameworks, writes and debugs code, runs tests, and pushes changes to repositories while providing real-time progress updates.
 
 ## Key Information
 

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -732,7 +732,7 @@
       "task_success_rate": null,
       "resource_usage": ""
     },
-    "description": "Devin is the world's first fully autonomous AI software engineer, created by Cognition. It is designed to be a tireless, skilled teammate that can work alongside human engineers or independently complete tasks."
+    "description": "Devin is the world's first fully autonomous AI software engineer from Cognition. Equipped with a shell, code editor, and browser, it can plan, build, test, and deploy software projects end to end, learning new frameworks from documentation and reporting progress in real time."
   },
   {
     "name": "Roo Code",

--- a/website/public/persona_ratings.json
+++ b/website/public/persona_ratings.json
@@ -477,36 +477,36 @@
   },
   "devin": {
     "automation_productivity": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 5,
+      "reasoning": "Devin autonomously plans and executes complex software projects, handling coding, testing, and deployment with minimal oversight."
     },
     "beginner_friendly_onboarding": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 2,
+      "reasoning": "The platform targets professional engineers and is available through a waitlisted beta, so newcomers face a steep learning curve."
     },
     "code_quality_testing": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 4,
+      "reasoning": "It runs unit tests, debugs failures, and fixes issues, but there is no emphasis on automated test generation."
     },
     "codebase_comprehension": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 5,
+      "reasoning": "Devin can onboard itself to unfamiliar repositories, read documentation, and fix bugs across large codebases."
     },
     "creative_multimodal_exploration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 1,
+      "reasoning": "The agent focuses on software engineering tasks and does not offer multimodal creativity features."
     },
     "data_experimental_flexibility": {
       "rating": 3,
-      "reasoning": "Research to be done."
+      "reasoning": "Devin can work with various tools and frameworks inside its environment, yet it is not specialized for data science experimentation."
     },
     "visual_no_code_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 1,
+      "reasoning": "Interaction is code-centric; there are no drag-and-drop or no-code interfaces."
     },
     "workflow_agent_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 2,
+      "reasoning": "Devin executes tasks end-to-end as a single agent but lacks tools for orchestrating multiple agents or pipelines."
     }
   },
   "engine": {

--- a/website/src/components/AgentDetailModal.jsx
+++ b/website/src/components/AgentDetailModal.jsx
@@ -72,7 +72,7 @@ function AgentDetailModal({ agent, onClose }) {
         <div className="flex flex-col md:flex-row gap-4 mb-4">
           <div className="border border-sparky-blue p-4 flex-1">
             <h3 className="font-archia mb-2">Description</h3>
-            <p className="text-sm">
+            <p className="text-sm whitespace-pre-line">
               {agent.description || "No description available."}
             </p>
           </div>


### PR DESCRIPTION
## Summary
- extend Devin overview with deeper capabilities
- populate Devin persona ratings and expose them on site
- ensure agent modal preserves long descriptions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e4e1d0b38832194a4b62639d03ad4