### PR TITLE
refactor: update OpenAI Codex profile and ratings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ The following agents have been profiled in this repository:
 - LogiQCLI (`agents/LogiQCLI`)
 - Qwen CLI (`agents/Qwen_CLI`)
 - Warp (`agents/Warp`)
-- OpenAI Codex (`agents/OpenAI_Codex`)
 - Aider (`agents/Aider`)
 
 ### IDE-Embedded Agents
@@ -56,6 +55,7 @@ The following agents have been profiled in this repository:
 
 ### Web & Virtualized Agents
 - ChatGPT agent (`agents/ChatGPT_agent`)
+- OpenAI Codex (`agents/OpenAI_Codex`)
 - devin (`agents/devin`)
 - enginelabs (`agents/enginelabs`)
 - Figma Make (`agents/Figma_Make`)

--- a/agents/OpenAI_Codex/agent_OpenAI_Codex.json
+++ b/agents/OpenAI_Codex/agent_OpenAI_Codex.json
@@ -1,19 +1,19 @@
 {
   "name": "OpenAI Codex",
-  "website": "https://openai.com/blog/openai-codex",
+  "website": "https://openai.com/chatgpt",
   "developer": "OpenAI",
   "key_features": [
-    "Translates natural language into code",
+    "Generates and edits code from natural language prompts within ChatGPT",
     "Supports multiple programming languages",
-    "Available via API or integrated tools"
+    "Provides conversational explanations and debugging assistance"
   ],
   "supported_models": [
-    "Codex series (e.g., code-davinci-002, code-cushman-001)"
+    "Integrated into ChatGPT; specific model names are not exposed"
   ],
-  "pricing_model": "Usage-based via the OpenAI API",
+  "pricing_model": "Available to ChatGPT Plus and enterprise subscribers",
   "benchmarks": {
     "swe_bench_score": null,
     "task_success_rate": null,
-    "resource_usage": "Depends on API usage; no public metrics"
+    "resource_usage": "Not publicly reported"
   }
 }

--- a/agents/OpenAI_Codex/persona_ratings_openai_codex.json
+++ b/agents/OpenAI_Codex/persona_ratings_openai_codex.json
@@ -1,34 +1,34 @@
 {
   "automation_productivity": {
-    "rating": 5,
-    "reasoning": "The Codex CLI is a powerful tool for automating development tasks and boosting productivity. It can be integrated into CI/CD pipelines and can handle a wide range of tasks, from code refactoring to generating unit tests. The non-interactive mode (`codex exec`) is specifically designed for automation."
+    "rating": 3,
+    "reasoning": "Within ChatGPT, Codex can quickly generate or refactor snippets, but it cannot directly plug into external build or deployment pipelines."
   },
   "beginner_friendly_onboarding": {
-    "rating": 3,
-    "reasoning": "The setup via `npm` or `brew` and the need for authentication can be a hurdle for absolute beginners. While documentation exists, there is no guided, interactive onboarding process. Access through a ChatGPT subscription is a plus, but it's not free."
+    "rating": 4,
+    "reasoning": "Using Codex inside ChatGPT requires no installation—users simply open a chat and describe the task."
   },
   "code_quality_testing": {
-    "rating": 4,
-    "reasoning": "Codex CLI can generate unit tests, check for vulnerabilities, and help explain code, which aids in debugging. The ability to iterate on tests until they pass is a particularly strong feature for improving code quality."
+    "rating": 2,
+    "reasoning": "Codex can suggest tests and point out potential issues, yet it cannot execute code or verify results automatically."
   },
   "codebase_comprehension": {
-    "rating": 4,
-    "reasoning": "The tool can analyze entire repositories, explain code snippets, and use project-specific `AGENTS.md` files for context. These features make it a strong assistant for understanding and navigating large and unfamiliar codebases."
+    "rating": 3,
+    "reasoning": "It explains and edits snippets pasted into the conversation, though it lacks direct access to large repositories."
   },
   "creative_multimodal_exploration": {
-    "rating": 1,
-    "reasoning": "The Codex CLI is a text-based tool focused on software development. It does not have any features for creative exploration or for working with other modalities like images or audio."
+    "rating": 2,
+    "reasoning": "Interactions are primarily text-based, offering limited support for other modalities beyond natural language."
   },
   "data_experimental_flexibility": {
-    "rating": 3,
-    "reasoning": "Codex CLI can generate code to interact with databases and can be used to script experiments. However, it is a general-purpose tool and lacks the specialized features of a dedicated MLOps platform for experiment tracking and data management."
+    "rating": 2,
+    "reasoning": "The assistant can draft analysis scripts but does not manage datasets or track experiment metadata."
   },
   "visual_no_code_development": {
-    "rating": 1,
-    "reasoning": "As a command-line interface (CLI), the Codex CLI is the antithesis of visual, no-code development. It is designed for developers who are comfortable working in a text-based terminal environment."
+    "rating": 2,
+    "reasoning": "The chat interface reduces manual coding but lacks visual drag-and-drop tooling common in no-code platforms."
   },
   "workflow_agent_orchestration": {
-    "rating": 4,
-    "reasoning": "With its non-interactive mode and support for the Model Context Protocol (MCP), the Codex CLI is well-suited for being a component in larger workflows and for orchestrating other agents and tools. It can be easily integrated into CI/CD pipelines."
+    "rating": 1,
+    "reasoning": "Codex inside ChatGPT operates as a standalone helper without mechanisms to coordinate other agents or tools."
   }
 }

--- a/agents/OpenAI_Codex/profile.md
+++ b/agents/OpenAI_Codex/profile.md
@@ -1,30 +1,30 @@
 # OpenAI Codex
 
 ## Overview
-OpenAI Codex is a descendant of GPT-3 that translates natural language into code.
+Within ChatGPT, OpenAI Codex acts as a conversational coding assistant that turns natural language prompts into executable code directly in the chat interface.
 
 ## Key Information
 - **Developer:** OpenAI
-- **Website:** [https://openai.com/blog/openai-codex](https://openai.com/blog/openai-codex)
-- **Pricing:** Usage-based via the OpenAI API
+- **Website:** [https://openai.com/chatgpt](https://openai.com/chatgpt)
+- **Pricing:** Included with ChatGPT Plus and enterprise plans
 
 ## Key Features
-- Translates natural language into code
+- Generates and edits code through conversational prompts
 - Supports multiple programming languages
-- Available via API or integrated tools
+- Provides inline explanations and debugging help inside ChatGPT
 
 ## Supported Models
-- Codex series (e.g., code-davinci-002, code-cushman-001)
+- Integrated into ChatGPT; specific model names are not exposed
 
 ## Benchmarks
 - **SWE-bench score:** Not available
 - **Task Success Rate:** Not available
-- **Resource Usage:** Depends on API usage; no public metrics
+- **Resource Usage:** Not publicly reported
 
 ## Qualitative Assessment
-- **Ease of Use:** Moderate – API usage requires programming knowledge.
-- **Documentation Quality:** Moderate – basic API references and guides.
-- **Onboarding Experience:** Moderate – requires API key setup and integration work.
+- **Ease of Use:** High – accessible through the ChatGPT interface with no setup.
+- **Documentation Quality:** Moderate – basic help center guidance.
+- **Onboarding Experience:** High – users simply start a ChatGPT conversation.
 
 ## Missing Data
-OpenAI has not published benchmark results or resource usage statistics for the Codex model as of May 2025.
+OpenAI has not published benchmark results or detailed resource metrics for Codex features within ChatGPT as of May 2025.

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -155,23 +155,23 @@
   },
   {
     "name": "OpenAI Codex",
-    "website": "https://openai.com/blog/openai-codex",
+    "website": "https://openai.com/chatgpt",
     "developer": "OpenAI",
     "key_features": [
-      "Translates natural language into code",
+      "Generates and edits code through conversational prompts",
       "Supports multiple programming languages",
-      "Available via API or integrated tools"
+      "Provides inline explanations and debugging help inside ChatGPT"
     ],
     "supported_models": [
-      "Codex series (e.g., code-davinci-002, code-cushman-001)"
+      "Integrated into ChatGPT; specific model names are not exposed"
     ],
-    "pricing_model": "Usage-based via the OpenAI API",
+    "pricing_model": "Available to ChatGPT Plus and enterprise subscribers",
     "benchmarks": {
       "swe_bench_score": null,
       "task_success_rate": null,
-      "resource_usage": "Depends on API usage; no public metrics"
+      "resource_usage": "Not publicly reported"
     },
-    "description": "OpenAI Codex is a descendant of GPT-3 that translates natural language into code."
+    "description": "OpenAI Codex is the coding assistant built into ChatGPT that turns natural language prompts into code."
   },
   {
     "name": "Letta",

--- a/website/public/persona_ratings.json
+++ b/website/public/persona_ratings.json
@@ -1021,36 +1021,36 @@
   },
   "openai_codex": {
     "automation_productivity": {
-      "rating": 5,
-      "reasoning": "The Codex CLI is a powerful tool for automating development tasks and boosting productivity. It can be integrated into CI/CD pipelines and can handle a wide range of tasks, from code refactoring to generating unit tests. The non-interactive mode (`codex exec`) is specifically designed for automation."
+      "rating": 3,
+      "reasoning": "Within ChatGPT, Codex can quickly generate or refactor snippets, but it cannot directly plug into external build or deployment pipelines."
     },
     "beginner_friendly_onboarding": {
-      "rating": 3,
-      "reasoning": "The setup via `npm` or `brew` and the need for authentication can be a hurdle for absolute beginners. While documentation exists, there is no guided, interactive onboarding process. Access through a ChatGPT subscription is a plus, but it's not free."
+      "rating": 4,
+      "reasoning": "Using Codex inside ChatGPT requires no installation—users simply open a chat and describe the task."
     },
     "code_quality_testing": {
-      "rating": 4,
-      "reasoning": "Codex CLI can generate unit tests, check for vulnerabilities, and help explain code, which aids in debugging. The ability to iterate on tests until they pass is a particularly strong feature for improving code quality."
+      "rating": 2,
+      "reasoning": "Codex can suggest tests and point out potential issues, yet it cannot execute code or verify results automatically."
     },
     "codebase_comprehension": {
-      "rating": 4,
-      "reasoning": "The tool can analyze entire repositories, explain code snippets, and use project-specific `AGENTS.md` files for context. These features make it a strong assistant for understanding and navigating large and unfamiliar codebases."
+      "rating": 3,
+      "reasoning": "It explains and edits snippets pasted into the conversation, though it lacks direct access to large repositories."
     },
     "creative_multimodal_exploration": {
-      "rating": 1,
-      "reasoning": "The Codex CLI is a text-based tool focused on software development. It does not have any features for creative exploration or for working with other modalities like images or audio."
+      "rating": 2,
+      "reasoning": "Interactions are primarily text-based, offering limited support for other modalities beyond natural language."
     },
     "data_experimental_flexibility": {
-      "rating": 3,
-      "reasoning": "Codex CLI can generate code to interact with databases and can be used to script experiments. However, it is a general-purpose tool and lacks the specialized features of a dedicated MLOps platform for experiment tracking and data management."
+      "rating": 2,
+      "reasoning": "The assistant can draft analysis scripts but does not manage datasets or track experiment metadata."
     },
     "visual_no_code_development": {
-      "rating": 1,
-      "reasoning": "As a command-line interface (CLI), the Codex CLI is the antithesis of visual, no-code development. It is designed for developers who are comfortable working in a text-based terminal environment."
+      "rating": 2,
+      "reasoning": "The chat interface reduces manual coding but lacks visual drag-and-drop tooling common in no-code platforms."
     },
     "workflow_agent_orchestration": {
-      "rating": 4,
-      "reasoning": "With its non-interactive mode and support for the Model Context Protocol (MCP), the Codex CLI is well-suited for being a component in larger workflows and for orchestrating other agents and tools. It can be easily integrated into CI/CD pipelines."
+      "rating": 1,
+      "reasoning": "Codex inside ChatGPT operates as a standalone helper without mechanisms to coordinate other agents or tools."
     }
   },
   "openhands": {


### PR DESCRIPTION
## Summary
- refocus OpenAI Codex profile and agent data on ChatGPT-based coding assistant
- refresh persona ratings to remove Codex CLI assumptions
- relocate OpenAI Codex to web & virtualized agents list for clarity

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e5132a70c8321a322ee9d514900b7