### PR TITLE
Add detailed AskCodi profile and ratings

### DIFF
--- a/agents/AskCodi/persona_ratings_askcodi.json
+++ b/agents/AskCodi/persona_ratings_askcodi.json
@@ -1,34 +1,34 @@
 {
   "automation_productivity": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 4,
+    "reasoning": "Generators for code, pipelines, and infrastructure automate many repetitive tasks and speed up development."
   },
   "beginner_friendly_onboarding": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 4,
+    "reasoning": "A free tier and editor plugins with simple sign-up make it approachable for new developers."
   },
   "code_quality_testing": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "Includes unit test generation, bug detection, and Big-O analysis, though deeper testing workflows are limited."
   },
   "codebase_comprehension": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "Code explanations and bug detector help understand unfamiliar code but large-scale repository analysis is minimal."
   },
   "creative_multimodal_exploration": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 1,
+    "reasoning": "The assistant is text-only and lacks support for images, audio, or other modalities."
   },
   "data_experimental_flexibility": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "Supports multiple model providers but offers little for data management or experiment tracking."
   },
   "visual_no_code_development": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 1,
+    "reasoning": "Focused on code editing; it does not provide drag-and-drop or template-driven interfaces."
   },
   "workflow_agent_orchestration": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "Automates individual coding tasks but lacks facilities for coordinating multi-agent workflows."
   }
 }

--- a/agents/AskCodi/profile.md
+++ b/agents/AskCodi/profile.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-AskCodi is an AI coding assistant from Assistiv AI that provides a wide range of tools to help developers write, refactor, and test their code.
+AskCodi is a developer productivity platform from Assistiv AI. It combines a web-based playground with IDE extensions to help developers generate, refactor, and test code across many languages. The service includes specialized generators for documentation, infrastructure files, and even SQL or regex snippets, letting users offload repetitive work to the assistant.
+
+Launched by Assistiv AI in 2021, AskCodi aims to streamline day-to-day programming tasks rather than replace developers. It taps into models from multiple providers so that users can choose between speed and quality, and it exposes most features through both the web app and editor plugins.
 
 ## Key Features
 
@@ -12,6 +14,18 @@ AskCodi is an AI coding assistant from Assistiv AI that provides a wide range of
 - Includes a Big-O analyzer, bug detector, and code explainer.
 - Has a sandbox for building and testing front-end code.
 - Integrates with VS Code, JetBrains, and Sublime Text.
+
+## Integrations and Workflow
+
+AskCodi offers official extensions for Visual Studio Code, JetBrains IDEs, and Sublime Text. These plugins expose the full suite of generators directly inside the editor and can pull context from open files to improve suggestions. The web sandbox, called **Codi Web**, provides a multi-file workspace for quick experiments and includes one-click export to GitHub. AskCodi also supplies a browser extension for generating code from documentation pages and an API for custom integrations.
+
+## Detailed Capabilities
+
+- **Code generation and refactoring:** Draft functions, translate between languages, and rewrite existing code for clarity or style.
+- **Infrastructure helpers:** Create Dockerfiles, Kubernetes manifests, CI/CD pipelines, and Makefiles.
+- **Quality tools:** Big-O complexity analysis, bug detection, code explanations, and automatic unit test generation.
+- **Documentation modules:** Generate comments, README files, and other developer docs from source code.
+- **Learning aids:** Explanation mode breaks down unfamiliar snippets step by step to help users understand new patterns.
 
 ## Supported Models
 

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -80,7 +80,8 @@
       "task_success_rate": null,
       "resource_usage": ""
     },
-    "description": "AskCodi is an AI coding assistant from Assistiv AI that provides a wide range of tools to help developers write, refactor, and test their code."
+    "description": "AskCodi is an AI coding assistant from Assistiv AI that provides a wide range of tools to help developers write, refactor, and test their code.",
+    "long_description": "AskCodi pairs a web playground with IDE plugins to generate and refactor code in many languages. It can draft unit tests, SQL queries, regex, and infrastructure files like Dockerfiles or CI/CD pipelines while also explaining code, detecting bugs, and analyzing Big-O performance."
   },
   {
     "name": "SWE-agent",

--- a/website/public/persona_ratings.json
+++ b/website/public/persona_ratings.json
@@ -137,36 +137,36 @@
   },
   "askcodi": {
     "automation_productivity": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 4,
+      "reasoning": "Generators for code, pipelines, and infrastructure automate many repetitive tasks and speed up development."
     },
     "beginner_friendly_onboarding": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 4,
+      "reasoning": "A free tier and editor plugins with simple sign-up make it approachable for new developers."
     },
     "code_quality_testing": {
       "rating": 3,
-      "reasoning": "Research to be done."
+      "reasoning": "Includes unit test generation, bug detection, and Big-O analysis, though deeper testing workflows are limited."
     },
     "codebase_comprehension": {
       "rating": 3,
-      "reasoning": "Research to be done."
+      "reasoning": "Code explanations and bug detector help understand unfamiliar code but large-scale repository analysis is minimal."
     },
     "creative_multimodal_exploration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 1,
+      "reasoning": "The assistant is text-only and lacks support for images, audio, or other modalities."
     },
     "data_experimental_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 2,
+      "reasoning": "Supports multiple model providers but offers little for data management or experiment tracking."
     },
     "visual_no_code_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 1,
+      "reasoning": "Focused on code editing; it does not provide drag-and-drop or template-driven interfaces."
     },
     "workflow_agent_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 2,
+      "reasoning": "Automates individual coding tasks but lacks facilities for coordinating multi-agent workflows."
     }
   },
   "chat.z.ai": {

--- a/website/src/components/AgentDetailModal.jsx
+++ b/website/src/components/AgentDetailModal.jsx
@@ -73,7 +73,7 @@ function AgentDetailModal({ agent, onClose }) {
           <div className="border border-sparky-blue p-4 flex-1">
             <h3 className="font-archia mb-2">Description</h3>
             <p className="text-sm whitespace-pre-line">
-              {agent.description || "No description available."}
+              {agent.long_description || agent.description || "No description available."}
             </p>
           </div>
           <div className="border border-sparky-blue p-4 flex-1">


### PR DESCRIPTION
## Summary
- expand AskCodi profile with background, integrations, and detailed capabilities
- populate AskCodi persona ratings and expose them with a long description in the agent modal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e52450ecc8321bc1abc6db991fa71