### PR TITLE
Add detailed profile and ratings for ChatGPT agent

### DIFF
--- a/agents/ChatGPT_agent/agent_ChatGPT_agent.json
+++ b/agents/ChatGPT_agent/agent_ChatGPT_agent.json
@@ -13,6 +13,8 @@
     "Latest models available to ChatGPT users"
   ],
   "pricing_model": "Subscription-based with usage limits (Pro: 400 messages/month, Plus: 40 messages/month)",
+  "description": "An optional agent mode in ChatGPT that can browse the web, run code, and compile multi-step research.",
+  "long_description": "Users guide the agent through iterative, interruptible workflows. It employs Deep Research, a remote browser called Operator, and a sandboxed terminal to execute Python, analyze data, and generate files across web, desktop, and mobile clients.",
   "benchmarks": {
     "swe_bench_score": 4.04,
     "swe_bench_source": "https://cognition.ai/blog/swe-bench-technical-report",

--- a/agents/ChatGPT_agent/persona_ratings_chatgpt_agent.json
+++ b/agents/ChatGPT_agent/persona_ratings_chatgpt_agent.json
@@ -1,34 +1,34 @@
 {
   "automation_productivity": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 4,
+    "reasoning": "The agent can automate multi-step tasks via its Operator for browsing and a sandboxed terminal to run scripts or build reports, reducing manual effort."
   },
   "beginner_friendly_onboarding": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 5,
+    "reasoning": "It is available directly inside the ChatGPT interface with a simple agent mode toggle and works across platforms without setup beyond a ChatGPT subscription."
   },
   "code_quality_testing": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "The terminal can execute linters and tests, but there are no dedicated code-quality analysis tools."
   },
   "codebase_comprehension": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "The agent can read and search code through the terminal, yet it lacks specialized features for navigating large codebases."
   },
   "creative_multimodal_exploration": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 4,
+    "reasoning": "Using the latest multimodal models and a remote browser, it can combine text, images, and web content for creative output."
   },
   "data_experimental_flexibility": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "The terminal runs Python and handles file uploads for analysis, though the environment is sandboxed with limited resources."
   },
   "visual_no_code_development": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "ChatGPT remains a text-based interface and does not provide drag-and-drop or no-code app builders."
   },
   "workflow_agent_orchestration": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "While it coordinates tasks across its built-in tools, it cannot orchestrate multiple agents or complex external pipelines."
   }
 }

--- a/agents/ChatGPT_agent/profile.md
+++ b/agents/ChatGPT_agent/profile.md
@@ -1,38 +1,44 @@
 # ChatGPT Agent
 
-**Developer:** OpenAI
+## Overview
 
-**Website:** [https://openai.com/index/introducing-chatgpt-agent/](https://openai.com/index/introducing-chatgpt-agent/)
+ChatGPT agent is an optional agent mode within the ChatGPT product that can carry out tasks with tools such as Deep Research, Operator, and a sandboxed Terminal. Users can guide the agent step by step, pause it at any time, and iteratively refine the output across web, desktop, and mobile clients.
+
+## Key Information
+
+- **Developer:** OpenAI
+- **Website:** [https://openai.com/index/introducing-chatgpt-agent/](https://openai.com/index/introducing-chatgpt-agent/)
+- **Pricing:** Subscription-based; usage counts against ChatGPT message limits (Pro 400 messages/month, Plus 40).
 
 ## Key Features
 
-*   **Iterative and Collaborative Workflows:** Designed for interactive sessions where users can guide and refine the agent's work.
-*   **Interruptible:** Users can pause the agent at any point to provide clarification or change the direction of the task.
-*   **Deep Research:** Capable of conducting multi-step research tasks and compiling the findings into comprehensive reports.
-*   **Operator:** Can interact with websites and applications through a remote visual browser environment to complete tasks.
-*   **Terminal Tool:** Provides a sandboxed terminal environment for executing code, performing data analysis, and generating files like slides or spreadsheets.
+- **Iterative and Collaborative Workflows:** Designed for interactive sessions where users can guide and refine the agent's work.
+- **Interruptible:** Users can pause the agent at any point to provide clarification or change the task.
+- **Deep Research:** Conducts multi-step research and compiles findings into reports.
+- **Operator:** Interacts with websites and applications through a remote visual browser environment.
+- **Terminal Tool:** Sandboxed terminal for executing code, data analysis, and generating files like slides or spreadsheets.
 
 ## Supported Models
 
-The ChatGPT agent is a feature within the ChatGPT product and uses the latest models available to ChatGPT users. It is accessible on web, mobile (iOS/Android), and desktop (macOS/Windows) platforms.
+The ChatGPT agent uses the latest models available to ChatGPT users. It is accessible on web, mobile (iOS/Android), and desktop (macOS/Windows) platforms.
 
 ## Pricing Model
 
 The ChatGPT agent's usage is tied to a user's ChatGPT subscription plan, with monthly message limits:
 
-*   **Pro Plan:** 400 messages per month.
-*   **Plus Plan:** 40 messages per month or an equivalent cost in credits under a flexible pricing model.
+- **Pro Plan:** 400 messages per month.
+- **Plus Plan:** 40 messages per month or an equivalent cost in credits under a flexible pricing model.
 
-Only user-initiated messages that advance the agent's task count towards this limit.
+Only user-initiated messages that advance the agent's task count toward this limit.
 
 ## Benchmarks
 
-- **SWE-bench score:** 18.00% (for SWE-agent + GPT 4) - [Source](https://www.swebench.com/)
+- **SWE-bench score:** 18.00% (for SWE-agent + GPT‑4) - [Source](https://www.swebench.com/)
 - **Task Success Rate:** Not available
 - **Resource Usage:** Not available
 
 ## Qualitative Assessment
 
-*   **Ease of Use:** 5/5 - The agent is designed to be highly interactive and user-friendly, allowing for natural language instructions and real-time adjustments.
-*   **Documentation Quality:** 4/5 - OpenAI provides official documentation through its Help Center, including articles specifically about the ChatGPT agent.
-*   **Onboarding Experience:** The agent can be easily activated within the ChatGPT interface by selecting "Agent mode" or using a slash command (`/agent`).
+- **Ease of Use:** 5/5 – The agent is highly interactive and user-friendly, allowing natural language instructions and real-time adjustments.
+- **Documentation Quality:** 4/5 – OpenAI provides official documentation through its Help Center, including articles about the ChatGPT agent.
+- **Onboarding Experience:** The agent can be activated within the ChatGPT interface by selecting "Agent mode" or using the `/agent` command.

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -775,7 +775,8 @@
       "task_success_rate": null,
       "resource_usage": "GPT-4 (assisted). GPT-3.5 (assisted) scored 1.34% on SWE-bench"
     },
-    "description": ""
+    "description": "An optional agent mode in ChatGPT that can browse the web, run code, and compile multi-step research.",
+    "long_description": "Users guide the agent through iterative, interruptible workflows. It employs Deep Research, a remote browser called Operator, and a sandboxed terminal to execute Python, analyze data, and generate files across web, desktop, and mobile clients."
   },
   {
     "name": "Minimax Agent",

--- a/website/public/persona_ratings.json
+++ b/website/public/persona_ratings.json
@@ -205,36 +205,36 @@
   },
   "chatgpt_agent": {
     "automation_productivity": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 4,
+      "reasoning": "The agent can automate multi-step tasks via its Operator for browsing and a sandboxed terminal to run scripts or build reports, reducing manual effort."
     },
     "beginner_friendly_onboarding": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 5,
+      "reasoning": "It is available directly inside the ChatGPT interface with a simple agent mode toggle and works across platforms without setup beyond a ChatGPT subscription."
     },
     "code_quality_testing": {
       "rating": 3,
-      "reasoning": "Research to be done."
+      "reasoning": "The terminal can execute linters and tests, but there are no dedicated code-quality analysis tools."
     },
     "codebase_comprehension": {
       "rating": 3,
-      "reasoning": "Research to be done."
+      "reasoning": "The agent can read and search code through the terminal, yet it lacks specialized features for navigating large codebases."
     },
     "creative_multimodal_exploration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 4,
+      "reasoning": "Using the latest multimodal models and a remote browser, it can combine text, images, and web content for creative output."
     },
     "data_experimental_flexibility": {
       "rating": 3,
-      "reasoning": "Research to be done."
+      "reasoning": "The terminal runs Python and handles file uploads for analysis, though the environment is sandboxed with limited resources."
     },
     "visual_no_code_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 2,
+      "reasoning": "ChatGPT remains a text-based interface and does not provide drag-and-drop or no-code app builders."
     },
     "workflow_agent_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 2,
+      "reasoning": "While it coordinates tasks across its built-in tools, it cannot orchestrate multiple agents or complex external pipelines."
     }
   },
   "claude_code": {

--- a/website/src/components/AgentDetailModal.jsx
+++ b/website/src/components/AgentDetailModal.jsx
@@ -73,7 +73,7 @@ function AgentDetailModal({ agent, onClose }) {
           <div className="border border-sparky-blue p-4 flex-1">
             <h3 className="font-archia mb-2">Description</h3>
             <p className="text-sm whitespace-pre-line">
-              {agent.description || "No description available."}
+              {agent.long_description || agent.description || "No description available."}
             </p>
           </div>
           <div className="border border-sparky-blue p-4 flex-1">


### PR DESCRIPTION
## Summary
- expand ChatGPT agent profile with overview, key information, and features
- provide persona ratings with reasoning and integrate into site data
- display longer descriptions in agent details modal

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e526820948321af97c0d9f5797452