### PR TITLE
docs: expand Claude Code profile

### DIFF
--- a/agents/Claude_Code/agent_Claude_Code.json
+++ b/agents/Claude_Code/agent_Claude_Code.json
@@ -2,6 +2,12 @@
   "name": "Claude Code",
   "website": "https://docs.anthropic.com/en/docs/claude-code/overview",
   "developer": "Anthropic",
+  "description": "Terminal-based coding assistant that understands your codebase and handles git workflows through natural language commands.",
+  "release_date": "2025-02-22",
+  "github_stars": 29800,
+  "requirements": "Node.js 18+",
+  "installation": "npm install -g @anthropic-ai/claude-code",
+  "privacy": "Feedback sent with /bug is stored for 30 days and not used for training.",
   "key_features": [
     "Build features from natural language descriptions.",
     "Debug and fix issues from error messages.",

--- a/agents/Claude_Code/profile.md
+++ b/agents/Claude_Code/profile.md
@@ -1,19 +1,26 @@
 # Claude Code
 
-Claude Code is a terminal-based AI agent developed by Anthropic to help developers build features, debug issues, and navigate codebases directly from the command line.
+## Overview
+Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows—all through natural language commands.
 
 ## Key Information
 - **Developer:** Anthropic
 - **Website:** [https://docs.anthropic.com/en/docs/claude-code/overview](https://docs.anthropic.com/en/docs/claude-code/overview)
+- **Release Date:** February 22, 2025
+- **GitHub Stars:** ~29.8k (Aug 2025)
 - **Pricing:** Based on API token consumption; approximately $6 per developer per day using Sonnet 4.
+- **Requirements:** Node.js 18+
 
 ## Key Features
-- Natural language to code generation.
-- Debugging and lint fixing based on error messages.
-- Codebase navigation and Q&A.
-- Automates tasks like release notes and test writing.
-- Action-oriented: can edit files, run commands, and create commits.
+- Build features from natural language descriptions.
+- Debug and fix issues from error messages.
+- Navigate and understand codebases.
+- Automate tasks like fixing lint issues, writing tests, and release notes.
+- Works in the terminal or IDE.
+- Handles git operations like editing files, running commands, and creating commits.
 - Scriptable and composable with Unix philosophy.
+- Built-in `/bug` command for reporting issues.
+- Feedback is stored for 30 days and not used for model training.
 - Enterprise-ready with self-hosting options on AWS or GCP.
 
 ## Supported Models
@@ -31,6 +38,10 @@ Claude Code is a terminal-based AI agent developed by Anthropic to help develope
 - **Terminal-Bench Accuracy:** 43.2% ± 1.3 – [Terminal-Bench Leaderboard](https://www.tbench.ai/leaderboard)
 - **Task Success Rate:** 0.432 (from Terminal-Bench accuracy)
 - **Resource Usage:** Not publicly documented.
+
+## Installation
+1. `npm install -g @anthropic-ai/claude-code`
+2. Navigate to your project directory and run `claude`.
 
 ## Qualitative Assessment
 - **Ease of Use:** High (3) – effective for developers comfortable with the command line.

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -655,6 +655,11 @@
     "name": "Claude Code",
     "website": "https://docs.anthropic.com/en/docs/claude-code/overview",
     "developer": "Anthropic",
+    "release_date": "2025-02-22",
+    "github_stars": 29800,
+    "requirements": "Node.js 18+",
+    "installation": "npm install -g @anthropic-ai/claude-code",
+    "privacy": "Feedback sent with /bug is stored for 30 days and not used for training.",
     "key_features": [
       "Build features from natural language descriptions.",
       "Debug and fix issues from error messages.",
@@ -684,7 +689,7 @@
       "resource_usage": "Not publicly documented",
       "terminal_bench_score_from_leaderboard": "43.2% ± 1.3"
     },
-    "description": ""
+    "description": "Terminal-based coding assistant that understands your codebase and handles git workflows through natural language commands."
   },
   {
     "name": "OpenHands",

--- a/website/src/components/AgentDetailModal.jsx
+++ b/website/src/components/AgentDetailModal.jsx
@@ -58,6 +58,21 @@ function AgentDetailModal({ agent, onClose }) {
           </button>
         </div>
         <p className="mb-2"><span className="font-archia">Developer:</span> {agent.developer}</p>
+        {agent.release_date && (
+          <p className="mb-2">
+            <span className="font-archia">Release Date:</span> {agent.release_date}
+          </p>
+        )}
+        {agent.github_stars && (
+          <p className="mb-2">
+            <span className="font-archia">GitHub Stars:</span> {agent.github_stars}
+          </p>
+        )}
+        {agent.requirements && (
+          <p className="mb-2">
+            <span className="font-archia">Requirements:</span> {agent.requirements}
+          </p>
+        )}
         <p className="mb-2"><span className="font-archia">Pricing:</span> {agent.pricing_model}</p>
         <div className="mb-4">
           <a
@@ -100,6 +115,17 @@ function AgentDetailModal({ agent, onClose }) {
             </div>
           </div>
         </div>
+        {agent.installation && (
+          <div className="border border-sparky-blue p-4 mb-4">
+            <h3 className="font-archia mb-2">Installation</h3>
+            <pre className="text-sm whitespace-pre-wrap">{agent.installation}</pre>
+          </div>
+        )}
+        {agent.privacy && (
+          <p className="mb-4">
+            <span className="font-archia">Privacy:</span> {agent.privacy}
+          </p>
+        )}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-4">
           {criteria.map((c) => {
             const info = agentRatings[c.id] || {};


### PR DESCRIPTION
## Summary
- capture release date, GitHub stars, runtime requirements, installation command, and privacy notes for Claude Code
- surface new Claude Code metadata on the website's solution details modal

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e52cff86483219b1320e4d98dd2d2