### PR TITLE
Add CrewAI persona ratings and long description

### DIFF
--- a/agents/CrewAI/agent_CrewAI.json
+++ b/agents/CrewAI/agent_CrewAI.json
@@ -20,5 +20,7 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  }
+  },
+  "description": "CrewAI is a Python framework for orchestrating role-playing, autonomous AI agents.",
+  "long_description": "Beyond simple agent chats, CrewAI lets developers compose role-based \"crews\" of agents and deterministic \"flows\" for event-driven automation. The lean, standalone framework offers deep customization over prompts, tools, and execution paths, enabling production-ready multi-agent systems."
 }

--- a/agents/CrewAI/persona_ratings_crewai.json
+++ b/agents/CrewAI/persona_ratings_crewai.json
@@ -1,34 +1,34 @@
 {
   "automation_productivity": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 4,
+    "reasoning": "Orchestrates multiple agents through crews and flows to automate complex tasks with minimal oversight."
   },
   "beginner_friendly_onboarding": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "Setup requires Python knowledge and understanding of multi-agent concepts despite good documentation."
   },
   "code_quality_testing": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "Focuses on orchestration and provides no native tools for testing or enforcing code quality."
   },
   "codebase_comprehension": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "Agents can integrate custom tools, but the framework lacks built-in features for navigating large codebases."
   },
   "creative_multimodal_exploration": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "Supports text-based agents and tool calls but offers no dedicated multimodal creativity features."
   },
   "data_experimental_flexibility": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "Open-source Python framework lets developers connect external APIs and data sources for custom experiments."
   },
   "visual_no_code_development": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 1,
+    "reasoning": "Configured through code and YAML with no drag-and-drop or no-code interface."
   },
   "workflow_agent_orchestration": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 5,
+    "reasoning": "Designed specifically for coordinating crews of agents and deterministic flows with event-driven control."
   }
 }

--- a/agents/CrewAI/profile.md
+++ b/agents/CrewAI/profile.md
@@ -4,6 +4,10 @@
 
 CrewAI is a Python framework for orchestrating role-playing, autonomous AI agents. It empowers developers to build and deploy sophisticated multi-agent systems that can work together to solve complex tasks.
 
+Beyond simple agent chats, CrewAI introduces the concepts of "crews" and "flows" to give developers fine-grained control over how agents collaborate. Crews allow autonomous agents to share context and delegate tasks, while Flows enable deterministic, event-driven execution paths for production-ready automation.
+
+The framework is lean and standalone—not tied to other orchestration stacks—and emphasizes deep customization. Developers can adjust prompts, tools, and behaviors at every level, combine multiple crews inside a single flow, and integrate with external APIs or data sources. A large community and extensive documentation support experimentation from small prototypes to enterprise workloads.
+
 ## Key Information
 
 - **Developer:** CrewAI Inc.

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -624,7 +624,8 @@
       "task_success_rate": null,
       "resource_usage": ""
     },
-    "description": "CrewAI is a Python framework for orchestrating role-playing, autonomous AI agents. It empowers developers to build and deploy sophisticated multi-agent systems that can work together to solve complex tasks."
+    "description": "CrewAI is a Python framework for orchestrating role-playing, autonomous AI agents. It empowers developers to build and deploy sophisticated multi-agent systems that can work together to solve complex tasks.",
+    "long_description": "Beyond simple agent chats, CrewAI lets developers compose role-based \"crews\" of agents and deterministic \"flows\" for event-driven automation. The lean, standalone framework offers deep customization over prompts, tools, and execution paths, enabling production-ready multi-agent systems."
   },
   {
     "name": "CodeGPT",

--- a/website/public/persona_ratings.json
+++ b/website/public/persona_ratings.json
@@ -375,36 +375,36 @@
   },
   "crewai": {
     "automation_productivity": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 4,
+      "reasoning": "Orchestrates multiple agents through crews and flows to automate complex tasks with minimal oversight."
     },
     "beginner_friendly_onboarding": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 2,
+      "reasoning": "Setup requires Python knowledge and understanding of multi-agent concepts despite good documentation."
     },
     "code_quality_testing": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 2,
+      "reasoning": "Focuses on orchestration and provides no native tools for testing or enforcing code quality."
     },
     "codebase_comprehension": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 2,
+      "reasoning": "Agents can integrate custom tools, but the framework lacks built-in features for navigating large codebases."
     },
     "creative_multimodal_exploration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 2,
+      "reasoning": "Supports text-based agents and tool calls but offers no dedicated multimodal creativity features."
     },
     "data_experimental_flexibility": {
       "rating": 3,
-      "reasoning": "Research to be done."
+      "reasoning": "Open-source Python framework lets developers connect external APIs and data sources for custom experiments."
     },
     "visual_no_code_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 1,
+      "reasoning": "Configured through code and YAML with no drag-and-drop or no-code interface."
     },
     "workflow_agent_orchestration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 5,
+      "reasoning": "Designed specifically for coordinating crews of agents and deterministic flows with event-driven control."
     }
   },
   "cursor": {


### PR DESCRIPTION
## Summary
- expand CrewAI profile with details on crews, flows, and customization
- add researched persona ratings and reasoning for CrewAI
- surface CrewAI long description and ratings in website data files

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e67be8a108321b9c4d49908b32d6f