### PR TITLE
Add DeepCode AI persona ratings and long description

### DIFF
--- a/agents/DeepCode_AI/agent_DeepCode_AI.json
+++ b/agents/DeepCode_AI/agent_DeepCode_AI.json
@@ -24,5 +24,7 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  }
+  },
+  "description": "DeepCode AI, developed by Snyk, is a powerful tool for automated code review, emphasizing static application security testing (SAST). It uses sophisticated algorithms to analyze code repositories and identifies security vulnerabilities and quality issues by scanning code in real time.",
+  "long_description": "DeepCode AI is Snyk's AI-powered static application security testing service. It combines symbolic analysis with generative models and Snyk's extensive vulnerability database to highlight insecure patterns, prioritize fixes by risk, and suggest automated remediation. Integrations with IDEs, Git platforms, and CI/CD pipelines let teams scan Java, JavaScript, Python, TypeScript, C#, Go, and more while they code."
 }

--- a/agents/DeepCode_AI/persona_ratings_deepcode_ai.json
+++ b/agents/DeepCode_AI/persona_ratings_deepcode_ai.json
@@ -1,34 +1,34 @@
 {
   "automation_productivity": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 4,
+    "reasoning": "Automatically scans code in IDEs and CI pipelines, suggesting fixes and prioritizing risks to reduce manual review."
   },
   "beginner_friendly_onboarding": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 2,
+    "reasoning": "Free tier and documentation exist, but setup requires linking repositories and understanding security workflows."
   },
   "code_quality_testing": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 5,
+    "reasoning": "Provides deep static analysis with an extensive vulnerability database and offers security autofixes."
   },
   "codebase_comprehension": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 4,
+    "reasoning": "Analyzes whole repositories using ASTs to surface context-aware issues."
   },
   "creative_multimodal_exploration": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 1,
+    "reasoning": "Focused solely on text-based code analysis without image or audio capabilities."
   },
   "data_experimental_flexibility": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 1,
+    "reasoning": "No built-in data analysis or experiment tracking beyond code scanning."
   },
   "visual_no_code_development": {
-    "rating": 3,
-    "reasoning": "Research to be done."
+    "rating": 1,
+    "reasoning": "Offers code review tools but no drag-and-drop or visual builders."
   },
   "workflow_agent_orchestration": {
     "rating": 3,
-    "reasoning": "Research to be done."
+    "reasoning": "Integrates with Git platforms and CI/CD pipelines to enforce security checks, though not a full orchestration system."
   }
 }

--- a/agents/DeepCode_AI/profile.md
+++ b/agents/DeepCode_AI/profile.md
@@ -4,6 +4,8 @@
 
 DeepCode AI, developed by Snyk, is a powerful tool for automated code review, emphasizing static application security testing (SAST). It uses sophisticated algorithms to analyze your code repositories and identifies security vulnerabilities and quality issues by scanning code in real-time.
 
+The service combines symbolic analysis with generative models and Snyk's vast vulnerability database to highlight insecure patterns, prioritize fixes by risk, and even suggest automated remediation where possible. Developers can catch issues before merging and maintain secure coding practices across projects.
+
 ## Key Information
 
 - **Developer:** Snyk
@@ -41,3 +43,13 @@ Snyk offers a free plan with limited tests. Paid plans (Team and Enterprise) are
 ## Getting Started
 
 To get started with DeepCode AI, you can visit the [official website](https://snyk.io/platform/deepcode-ai/) and sign up for a plan.
+
+## Integrations and Language Support
+
+DeepCode AI plugs into GitHub, GitLab, Bitbucket, and common CI/CD systems. IDE extensions for JetBrains, Visual Studio Code, and the Snyk web dashboard let teams review code as they write it. The service supports popular languages such as Java, JavaScript, Python, TypeScript, C#, and Go.
+
+## Ideal Use Cases
+
+- Security auditing of pull requests before merge
+- Continuous monitoring of repositories for new vulnerabilities
+- Enforcing secure coding practices in DevOps pipelines

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -280,7 +280,8 @@
       "task_success_rate": null,
       "resource_usage": ""
     },
-    "description": "DeepCode AI, developed by Snyk, is a powerful tool for automated code review, emphasizing static application security testing (SAST). It uses sophisticated algorithms to analyze your code repositories and identifies security vulnerabilities and quality issues by scanning code in real-time."
+    "description": "DeepCode AI, developed by Snyk, is a powerful tool for automated code review, emphasizing static application security testing (SAST). It uses sophisticated algorithms to analyze your code repositories and identifies security vulnerabilities and quality issues by scanning code in real-time.",
+    "long_description": "DeepCode AI is Snyk's AI-powered static application security testing service. It combines symbolic analysis with generative models and Snyk's extensive vulnerability database to highlight insecure patterns, prioritize fixes by risk, and suggest automated remediation. Integrations with IDEs, Git platforms, and CI/CD pipelines let teams scan Java, JavaScript, Python, TypeScript, C#, Go, and more while they code."
   },
   {
     "name": "GitHub Copilot",

--- a/website/public/persona_ratings.json
+++ b/website/public/persona_ratings.json
@@ -443,36 +443,36 @@
   },
   "deepcode_ai": {
     "automation_productivity": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 4,
+      "reasoning": "Automatically scans code in IDEs and CI pipelines, suggesting fixes and prioritizing risks to reduce manual review."
     },
     "beginner_friendly_onboarding": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 2,
+      "reasoning": "Free tier and documentation exist, but setup requires linking repositories and understanding security workflows."
     },
     "code_quality_testing": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 5,
+      "reasoning": "Provides deep static analysis with an extensive vulnerability database and offers security autofixes."
     },
     "codebase_comprehension": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 4,
+      "reasoning": "Analyzes whole repositories using ASTs to surface context-aware issues."
     },
     "creative_multimodal_exploration": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 1,
+      "reasoning": "Focused solely on text-based code analysis without image or audio capabilities."
     },
     "data_experimental_flexibility": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 1,
+      "reasoning": "No built-in data analysis or experiment tracking beyond code scanning."
     },
     "visual_no_code_development": {
-      "rating": 3,
-      "reasoning": "Research to be done."
+      "rating": 1,
+      "reasoning": "Offers code review tools but no drag-and-drop or visual builders."
     },
     "workflow_agent_orchestration": {
       "rating": 3,
-      "reasoning": "Research to be done."
+      "reasoning": "Integrates with Git platforms and CI/CD pipelines to enforce security checks, though not a full orchestration system."
     }
   },
   "devin": {


### PR DESCRIPTION
## Summary
- expand DeepCode AI profile with integration details and ideal use cases
- add researched persona ratings for DeepCode AI
- surface long description and persona ratings on the website data so solution details show richer information

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e68254d5c832197cd7120bf220b62