### PR TITLE
Fix agent key sanitization for SQLAI ratings

### DIFF
--- a/website/src/components/AgentDetailModal.jsx
+++ b/website/src/components/AgentDetailModal.jsx
@@ -39,9 +39,15 @@ function AgentDetailModal({ agent, onClose }) {
     return filled + empty;
   };
 
-  const agentKey = agent.name
-    ?.toLowerCase()
-    .replace(/\s+/g, "_");
+  const getAgentKey = (name) => {
+    if (!name) return "";
+    const lower = name.toLowerCase();
+    const base = lower.split(".")[0];
+    const withSpaces = base.replace(/\s+/g, "_");
+    return withSpaces.replace(/[^a-z0-9_]/g, "_");
+  };
+
+  const agentKey = getAgentKey(agent.name);
   const agentRatings = ratings[agentKey] || {};
 
   return (


### PR DESCRIPTION
## Summary
- Sanitize agent names in AgentDetailModal so ratings load for agents with special characters (e.g., `SQLAI.ai`)

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e6991972c832195134cefb5f7d62f