### PR TITLE
Remove duplicate Minimax agent entry

### DIFF
--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -446,30 +446,6 @@
     "description": "Engine is a remote AI software engineer from Engine Labs that works in an isolated virtual machine to turn issues into pull requests. It integrates with popular project management tools and can run in autopilot mode to respond to code reviews and CI/CD events."
   },
   {
-    "name": "Minimax agent",
-    "website": "https://www.minimaxi.com/",
-    "developer": "MiniMax",
-    "key_features": [
-      "Text Model (MiniMax M1) with 1M token input",
-      "Video Model (MiniMax Hailuo 02) with 1080p output",
-      "Audio Model (MiniMax Speech 02) for speech generation",
-      "MCP Server for developers (Video, Image, Speech generation, Voice Cloning)",
-      "AI-native applications: MiniMax Chat, MiniMax Agent, Hailuo Video, MiniMax Audio, Talkie"
-    ],
-    "supported_models": [
-      "MiniMax M1 (Text)",
-      "MiniMax Hailuo 02 (Video)",
-      "MiniMax Speech 02 (Audio)"
-    ],
-    "pricing_model": "MiniMax M1 (text): $0.40 per 1M input tokens; Speech-02-HD (audio): $100 per 1M characters; Hailuo 02 (video): from $0.28 per video",
-    "benchmarks": {
-      "swe_bench_score": null,
-      "task_success_rate": null,
-      "resource_usage": "No public benchmarks found"
-    },
-    "description": "Minimax Agent is part of the MiniMax platform, delivering multimodal AI for text, audio, and video generation. It uses long-context models and toolkits to help developers build autonomous applications and creative media workflows."
-  },
-  {
     "name": "Gemini CLI",
     "website": "https://github.com/google-gemini/gemini-cli",
     "developer": "Google",


### PR DESCRIPTION
## Summary
- remove duplicate Minimax agent entry from agents table

## Testing
- `npm test` (fails: missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e6b070044832192cf7447625c3e74