### PR TITLE
Add Zapier agent profile and persona ratings

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The following agents have been profiled in this repository:
 - chat.z.ai (`agents/chat.z.ai`)
 - Perplexity Labs (`agents/Perplexity_Labs`)
 - v0.app (`agents/v0.app`)
+- Zapier (`agents/Zapier`)
 
 ### Agent Frameworks
 - CrewAI (`agents/CrewAI`)

--- a/agents/Zapier/agent_Zapier.json
+++ b/agents/Zapier/agent_Zapier.json
@@ -1,0 +1,28 @@
+{
+  "name": "Zapier",
+  "website": "https://zapier.com/",
+  "developer": "Zapier Inc.",
+  "key_features": [
+    "No-code workflow automation connecting thousands of apps",
+    "Drag-and-drop visual builder with multi-step workflows and conditional logic",
+    "AI-powered natural language automation builder and Zapier AI Actions",
+    "Code steps for custom JavaScript or Python",
+    "Extensive template library and shared Zaps"
+  ],
+  "supported_models": [
+    "OpenAI GPT-4 and GPT-3.5",
+    "Anthropic Claude",
+    "Google Gemini"
+  ],
+  "pricing_model": "Freemium with paid plans starting at $19.99/month",
+  "description": "Zapier is a web-based automation service that connects apps and automates workflows with a visual builder and optional AI features.",
+  "long_description": "Zapier lets users build \"Zaps\" that trigger actions across thousands of services. Its drag-and-drop interface, code steps, and AI Actions allow both non\u2011technical and technical users to automate complex multi-step processes without managing infrastructure.",
+  "benchmarks": {
+    "swe_bench_score": null,
+    "swe_bench_source": null,
+    "terminal_bench_score": null,
+    "terminal_bench_source": null,
+    "task_success_rate": null,
+    "resource_usage": null
+  }
+}

--- a/agents/Zapier/persona_ratings_zapier.json
+++ b/agents/Zapier/persona_ratings_zapier.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 5,
+    "reasoning": "Automates tasks across thousands of apps, with multi-step workflows, conditional logic, and AI Actions that reduce manual effort."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 4,
+    "reasoning": "Web-based interface with templates and natural language Zap creation is accessible, though complex workflows require some learning."
+  },
+  "code_quality_testing": {
+    "rating": 1,
+    "reasoning": "Platform focuses on app automation and provides no built-in tools for code quality or testing."
+  },
+  "codebase_comprehension": {
+    "rating": 1,
+    "reasoning": "Does not analyze or understand source code; workflows operate at the application level."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Integrations with AI services allow text and media generation, but creativity depends on connected apps rather than native features."
+  },
+  "data_experimental_flexibility": {
+    "rating": 4,
+    "reasoning": "Supports custom JavaScript/Python steps and connections to many data sources, enabling flexible data handling."
+  },
+  "visual_no_code_development": {
+    "rating": 5,
+    "reasoning": "Drag-and-drop builder enables complex automations without coding knowledge."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 4,
+    "reasoning": "Handles multi-step processes with branching, scheduling, and AI-driven actions, providing strong orchestration capabilities."
+  }
+}

--- a/agents/Zapier/profile.md
+++ b/agents/Zapier/profile.md
@@ -1,0 +1,37 @@
+# Zapier
+
+## Overview
+
+Zapier is a web-based automation platform that connects apps and services, enabling users to build workflows called Zaps without code. Recent AI features allow natural language automation building and let large language models run actions across integrations.
+
+## Key Information
+
+- **Developer:** Zapier Inc.
+- **Website:** [https://zapier.com/](https://zapier.com/)
+- **Pricing:** Freemium with paid plans starting at $19.99 per month
+
+## Key Features
+
+- **No-code builder:** Create Zaps with a drag-and-drop interface.
+- **Multi-step workflows:** Supports conditional logic, branching, and scheduling.
+- **AI assistance:** Natural language Zap creation and AI Actions that let LLMs execute tasks.
+- **Code steps:** Run custom JavaScript or Python when needed.
+- **Templates library:** Thousands of prebuilt Zaps for common use cases.
+
+## Supported Models
+
+- OpenAI GPT-4 and GPT-3.5
+- Anthropic Claude
+- Google Gemini
+
+## Benchmarks
+
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+
+- **Ease of Use:** Not available
+- **Documentation Quality:** Not available
+- **Onboarding Experience:** Not available

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -191,9 +191,9 @@
     ],
     "pricing_model": "Cloud-based platform with a free tier and enterprise options.",
     "benchmarks": {
-      "terminal_bench_score": "42.5% ± 0.8",
+      "terminal_bench_score": "42.5% \u00b1 0.8",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
-      "terminal_bench_score_from_leaderboard": "42.5% ± 0.8"
+      "terminal_bench_score_from_leaderboard": "42.5% \u00b1 0.8"
     },
     "description": "Letta is a platform for building stateful AI agents that retain long-term memory and expose their capabilities through REST APIs. Built on MemGPT, it offers tools to visualize agent reasoning and integrate custom tools across multiple frameworks."
   },
@@ -216,11 +216,11 @@
     ],
     "pricing_model": "Requires an OpenAI API key or a paid OpenAI account (Plus/Pro).",
     "benchmarks": {
-      "terminal_bench_score": "20.0% ± 1.5",
+      "terminal_bench_score": "20.0% \u00b1 1.5",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.2,
       "resource_usage": "Runs locally; resource usage depends on chosen model",
-      "terminal_bench_score_from_leaderboard": "20.0% ± 1.5"
+      "terminal_bench_score_from_leaderboard": "20.0% \u00b1 1.5"
     },
     "description": "Codex CLI is an open-source coding agent from OpenAI that runs locally on your computer and interacts with your terminal."
   },
@@ -345,7 +345,7 @@
       "task_success_rate": null,
       "resource_usage": ""
     },
-    "description": "Amazon CodeWhisperer is a machine learning (ML)–powered service that helps improve developer productivity by generating code recommendations based on their comments in natural language and code in the integrated development environment (IDE). It is in the process of being integrated into Amazon Q Developer."
+    "description": "Amazon CodeWhisperer is a machine learning (ML)\u2013powered service that helps improve developer productivity by generating code recommendations based on their comments in natural language and code in the integrated development environment (IDE). It is in the process of being integrated into Amazon Q Developer."
   },
   {
     "name": "Tabnine",
@@ -667,11 +667,11 @@
     "benchmarks": {
       "swe_bench_score": 49,
       "swe_bench_source": "https://www.anthropic.com/research/swe-bench-sonnet",
-      "terminal_bench_score": "43.2% ± 1.3",
+      "terminal_bench_score": "43.2% \u00b1 1.3",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.432,
       "resource_usage": "Not publicly documented",
-      "terminal_bench_score_from_leaderboard": "43.2% ± 1.3"
+      "terminal_bench_score_from_leaderboard": "43.2% \u00b1 1.3"
     },
     "description": "Terminal-based coding assistant that understands your codebase and handles git workflows through natural language commands."
   },
@@ -691,11 +691,11 @@
     ],
     "pricing_model": "Open-source under the MIT License; free for self-hosting with optional paid hosting via Daytona",
     "benchmarks": {
-      "terminal_bench_score": "41.3% ± 0.7",
+      "terminal_bench_score": "41.3% \u00b1 0.7",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.413,
       "resource_usage": "Not publicly documented; depends on hosting environment and model",
-      "terminal_bench_score_from_leaderboard": "41.3% ± 0.7"
+      "terminal_bench_score_from_leaderboard": "41.3% \u00b1 0.7"
     },
     "description": "OpenHands is an open-source AI coding agent and framework from Daytona that aims to let agents perform end-to-end software development tasks."
   },
@@ -855,11 +855,11 @@
     ],
     "pricing_model": "Open-source",
     "benchmarks": {
-      "terminal_bench_score": "42.0% ± 1.3",
+      "terminal_bench_score": "42.0% \u00b1 1.3",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.42,
       "resource_usage": "Depends on local hardware and model; no public metrics",
-      "terminal_bench_score_from_leaderboard": "42.0% ± 1.3"
+      "terminal_bench_score_from_leaderboard": "42.0% \u00b1 1.3"
     },
     "description": "Goose is an open-source, on-machine AI agent from Block that automates engineering tasks autonomously."
   },
@@ -904,7 +904,7 @@
     ],
     "pricing_model": "Research project, likely free to use.",
     "benchmarks": {
-      "terminal_bench_score": "39.9% ± 1.0",
+      "terminal_bench_score": "39.9% \u00b1 1.0",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.399,
       "resource_usage": "Not publicly documented; depends on remote environment and model"
@@ -983,7 +983,7 @@
       "task_success_rate": 0.52,
       "resource_usage": "Not publicly documented; depends on local hardware and active agents",
       "swe_bench_score": "71%",
-      "terminal_bench_score_from_leaderboard": "52.0% ± 1.0"
+      "terminal_bench_score_from_leaderboard": "52.0% \u00b1 1.0"
     },
     "description": "Warp is an agentic development environment and terminal that enables fast, native interactions with multiple AI agents across the development workflow."
   },
@@ -1116,5 +1116,33 @@
       "resource_usage": ""
     },
     "description": "chat.z.ai is Zhipu AI's web interface for its GLM models, offering long-context conversations with GLM-4.5 and tools for coding assistance, web browsing, plugins, and function calling to build full-stack applications."
+  },
+  {
+    "name": "Zapier",
+    "website": "https://zapier.com/",
+    "developer": "Zapier Inc.",
+    "key_features": [
+      "No-code workflow automation connecting thousands of apps",
+      "Drag-and-drop visual builder with multi-step workflows and conditional logic",
+      "AI-powered natural language automation builder and Zapier AI Actions",
+      "Code steps for custom JavaScript or Python",
+      "Extensive template library and shared Zaps"
+    ],
+    "supported_models": [
+      "OpenAI GPT-4 and GPT-3.5",
+      "Anthropic Claude",
+      "Google Gemini"
+    ],
+    "pricing_model": "Freemium with paid plans starting at $19.99/month",
+    "description": "Zapier is a web-based automation service that connects apps and automates workflows with a visual builder and optional AI features.",
+    "long_description": "Zapier lets users build \"Zaps\" that trigger actions across thousands of services. Its drag-and-drop interface, code steps, and AI Actions allow both non\u2011technical and technical users to automate complex multi-step processes without managing infrastructure.",
+    "benchmarks": {
+      "swe_bench_score": null,
+      "swe_bench_source": null,
+      "terminal_bench_score": null,
+      "terminal_bench_source": null,
+      "task_success_rate": null,
+      "resource_usage": null
+    }
   }
 ]

--- a/website/public/persona_ratings.json
+++ b/website/public/persona_ratings.json
@@ -1026,7 +1026,7 @@
     },
     "beginner_friendly_onboarding": {
       "rating": 4,
-      "reasoning": "Using Codex inside ChatGPT requires no installation—users simply open a chat and describe the task."
+      "reasoning": "Using Codex inside ChatGPT requires no installation\u2014users simply open a chat and describe the task."
     },
     "code_quality_testing": {
       "rating": 2,
@@ -1527,6 +1527,40 @@
     "workflow_agent_orchestration": {
       "rating": 3,
       "reasoning": "Configuration is managed through a single YAML file, giving the model flexibility but without a dedicated multi-agent orchestration layer."
+    }
+  },
+  "zapier": {
+    "automation_productivity": {
+      "rating": 5,
+      "reasoning": "Automates tasks across thousands of apps, with multi-step workflows, conditional logic, and AI Actions that reduce manual effort."
+    },
+    "beginner_friendly_onboarding": {
+      "rating": 4,
+      "reasoning": "Web-based interface with templates and natural language Zap creation is accessible, though complex workflows require some learning."
+    },
+    "code_quality_testing": {
+      "rating": 1,
+      "reasoning": "Platform focuses on app automation and provides no built-in tools for code quality or testing."
+    },
+    "codebase_comprehension": {
+      "rating": 1,
+      "reasoning": "Does not analyze or understand source code; workflows operate at the application level."
+    },
+    "creative_multimodal_exploration": {
+      "rating": 3,
+      "reasoning": "Integrations with AI services allow text and media generation, but creativity depends on connected apps rather than native features."
+    },
+    "data_experimental_flexibility": {
+      "rating": 4,
+      "reasoning": "Supports custom JavaScript/Python steps and connections to many data sources, enabling flexible data handling."
+    },
+    "visual_no_code_development": {
+      "rating": 5,
+      "reasoning": "Drag-and-drop builder enables complex automations without coding knowledge."
+    },
+    "workflow_agent_orchestration": {
+      "rating": 4,
+      "reasoning": "Handles multi-step processes with branching, scheduling, and AI-driven actions, providing strong orchestration capabilities."
     }
   }
 }


### PR DESCRIPTION
## Summary
- add Zapier agent profile and structured metadata
- score Zapier across personas and expose in aggregated ratings
- register Zapier in website agent table

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ed6642fec8321ad12345a837d9d46