### PR TITLE
feat: add theme selector and dark mode

### DIFF
--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -26,15 +26,15 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <header className="bg-gray-100 p-4">
+    <div className="min-h-screen flex flex-col bg-white dark:bg-gray-900 text-stratos-blue dark:text-gray-100">
+      <header className="bg-gray-100 dark:bg-gray-800 p-4">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <h1 className="text-2xl font-bold text-stratos-blue">Open AI Agent Research</h1>
+          <h1 className="text-2xl font-bold text-stratos-blue dark:text-highlight-green">Open AI Agent Research</h1>
           <a
             href="https://github.com/bjmolitor/AIAgentResearch"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-stratos-blue underline"
+            className="text-stratos-blue dark:text-sparky-blue underline"
           >
             (MIT licensed - contributors wanted.)
           </a>
@@ -58,8 +58,8 @@ function App() {
           />
         </Routes>
       </main>
-      <footer className="bg-gray-100 p-4 text-center">
-        <p className="text-stratos-blue">&copy; 2024 Open AI Agent Research</p>
+      <footer className="bg-gray-100 dark:bg-gray-800 p-4 text-center">
+        <p className="text-stratos-blue dark:text-gray-100">&copy; 2024 Open AI Agent Research</p>
       </footer>
       <AgentDetailModal agent={selectedAgent} onClose={handleCloseModal} />
       <PersonasOverlay isOpen={showPersonas} onClose={handleClosePersonas} />

--- a/website/src/components/AgentTable.jsx
+++ b/website/src/components/AgentTable.jsx
@@ -130,8 +130,8 @@ function AgentTable({ onAgentClick, filterNames, searchTerm = "" }) {
 
   return (
     <div className="overflow-x-auto">
-      <table className="min-w-full text-sm text-stratos-blue border border-background-blue">
-        <thead className="bg-background-blue text-white">
+      <table className="min-w-full text-sm text-stratos-blue dark:text-gray-100 border border-background-blue dark:border-gray-700">
+        <thead className="bg-background-blue text-white dark:bg-stratos-blue">
           <tr>
             <th className="px-4 py-2 font-archia">Name</th>
             <th className="px-4 py-2 font-archia">Developer</th>
@@ -162,7 +162,7 @@ function AgentTable({ onAgentClick, filterNames, searchTerm = "" }) {
         </thead>
         <tbody>
           {sortedAgents.map((agent) => (
-            <tr key={agent.name} className="odd:bg-white even:bg-background-blue/10">
+            <tr key={agent.name} className="odd:bg-white even:bg-background-blue/10 dark:odd:bg-gray-800 dark:even:bg-gray-700">
               <td className="px-4 py-2">
                 <button
                   type="button"

--- a/website/src/components/ThemeSelector.jsx
+++ b/website/src/components/ThemeSelector.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+function ThemeSelector() {
+  const [theme, setTheme] = useState(
+    () => localStorage.getItem("theme") || "system"
+  );
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const applyTheme = () => {
+      if (theme === "system") {
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        root.classList.toggle("dark", prefersDark);
+      } else {
+        root.classList.toggle("dark", theme === "dark");
+      }
+    };
+
+    applyTheme();
+
+    if (theme === "system") {
+      const media = window.matchMedia("(prefers-color-scheme: dark)");
+      const listener = () => applyTheme();
+      media.addEventListener("change", listener);
+      return () => media.removeEventListener("change", listener);
+    }
+  }, [theme]);
+
+  const handleChange = (e) => {
+    const value = e.target.value;
+    setTheme(value);
+    localStorage.setItem("theme", value);
+  };
+
+  return (
+    <select
+      value={theme}
+      onChange={handleChange}
+      className="border px-2 py-1 rounded font-archia text-stratos-blue dark:text-gray-100 dark:bg-gray-800 dark:border-gray-700"
+    >
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+      <option value="system">System</option>
+    </select>
+  );
+}
+
+export default ThemeSelector;

--- a/website/src/main.jsx
+++ b/website/src/main.jsx
@@ -4,6 +4,12 @@ import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
+const storedTheme = localStorage.getItem('theme') || 'system'
+const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+if (storedTheme === 'dark' || (storedTheme === 'system' && systemPrefersDark)) {
+  document.documentElement.classList.add('dark')
+}
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>

--- a/website/src/pages/Home.jsx
+++ b/website/src/pages/Home.jsx
@@ -1,26 +1,30 @@
 import { useState } from "react";
 import AgentTable from "../components/AgentTable";
+import ThemeSelector from "../components/ThemeSelector";
 
 function Home({ onAgentClick, onOpenPersonas }) {
   const [searchTerm, setSearchTerm] = useState("");
 
   return (
     <div>
-      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center">
-        <button
-          type="button"
-          onClick={onOpenPersonas}
-          className="bg-stratos-blue text-white px-4 py-2 rounded font-archia"
-        >
-          Can you recommend something?
-        </button>
-        <input
-          type="text"
-          placeholder="Search agents..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          className="border px-2 py-1 rounded font-archia text-stratos-blue"
-        />
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <button
+            type="button"
+            onClick={onOpenPersonas}
+            className="bg-stratos-blue text-white px-4 py-2 rounded font-archia dark:bg-sparky-blue dark:text-gray-900"
+          >
+            Can you recommend something?
+          </button>
+          <input
+            type="text"
+            placeholder="Search agents..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="border px-2 py-1 rounded font-archia text-stratos-blue dark:text-gray-100 dark:bg-gray-800 dark:border-gray-700"
+          />
+        </div>
+        <ThemeSelector />
       </div>
       <AgentTable onAgentClick={onAgentClick} searchTerm={searchTerm} />
     </div>

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: "class",
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- add theme selector supporting light, dark, and system themes
- implement dark mode styling across app and agent table
- initialize theme from user preference or system settings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ed992f5748321b4b40305a2572de2