### PR TITLE
feat: add agent table export

### DIFF
--- a/website/src/pages/Home.jsx
+++ b/website/src/pages/Home.jsx
@@ -1,8 +1,10 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import AgentTable from "../components/AgentTable";
 
 function Home({ onAgentClick, onOpenPersonas }) {
   const [searchTerm, setSearchTerm] = useState("");
+  const [showExport, setShowExport] = useState(false);
+  const tableRef = useRef(null);
 
   return (
     <div>
@@ -14,6 +16,49 @@ function Home({ onAgentClick, onOpenPersonas }) {
         >
           Can you recommend something?
         </button>
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setShowExport((v) => !v)}
+            className="bg-stratos-blue text-white px-4 py-2 rounded font-archia"
+          >
+            Export
+          </button>
+          {showExport && (
+            <div className="absolute z-10 mt-1 bg-white border rounded shadow">
+              <button
+                type="button"
+                className="block w-full px-4 py-2 text-left hover:bg-gray-100"
+                onClick={() => {
+                  tableRef.current?.exportData("json");
+                  setShowExport(false);
+                }}
+              >
+                JSON
+              </button>
+              <button
+                type="button"
+                className="block w-full px-4 py-2 text-left hover:bg-gray-100"
+                onClick={() => {
+                  tableRef.current?.exportData("csv");
+                  setShowExport(false);
+                }}
+              >
+                CSV
+              </button>
+              <button
+                type="button"
+                className="block w-full px-4 py-2 text-left hover:bg-gray-100"
+                onClick={() => {
+                  tableRef.current?.exportData("md");
+                  setShowExport(false);
+                }}
+              >
+                Markdown
+              </button>
+            </div>
+          )}
+        </div>
         <input
           type="text"
           placeholder="Search agents..."
@@ -22,7 +67,11 @@ function Home({ onAgentClick, onOpenPersonas }) {
           className="border px-2 py-1 rounded font-archia text-stratos-blue"
         />
       </div>
-      <AgentTable onAgentClick={onAgentClick} searchTerm={searchTerm} />
+      <AgentTable
+        ref={tableRef}
+        onAgentClick={onAgentClick}
+        searchTerm={searchTerm}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- include website links in AgentTable and exported data
- replace multiple export buttons with a single dropdown near the search bar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ed867f5c88321b65616709f4e1157