### PR TITLE
Move theme selector below agent table

### DIFF
--- a/website/src/pages/Home.jsx
+++ b/website/src/pages/Home.jsx
@@ -68,12 +68,14 @@ function Home({ onAgentClick, onOpenPersonas }) {
           className="border px-2 py-1 rounded font-archia text-stratos-blue"
         />      
       </div>
-      <ThemeSelector />
       <AgentTable
         ref={tableRef}
         onAgentClick={onAgentClick}
         searchTerm={searchTerm}
       />
+      <div className="mt-4 flex justify-end">
+        <ThemeSelector />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Place theme selector beneath the AgentTable and header link to keep it at the bottom right of the page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ede9282c88321a8bcb62935cba9a9