### PR TITLE
Move theme selector above agent table

### DIFF
--- a/website/src/pages/Home.jsx
+++ b/website/src/pages/Home.jsx
@@ -66,9 +66,11 @@ function Home({ onAgentClick, onOpenPersonas }) {
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
           className="border px-2 py-1 rounded font-archia text-stratos-blue"
-        />      
+        />
+        <div className="ml-auto">
+          <ThemeSelector />
+        </div>
       </div>
-      <ThemeSelector />
       <AgentTable
         ref={tableRef}
         onAgentClick={onAgentClick}


### PR DESCRIPTION
## Summary
- Place the theme selector alongside the search field and buttons so it appears above the agent table

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ede9282c88321a8bcb62935cba9a9