### PR TITLE
feat: dynamic persona recommendations

### DIFF
--- a/website/src/components/AgentTable.jsx
+++ b/website/src/components/AgentTable.jsx
@@ -6,7 +6,13 @@ import {
 } from "react";
 
 const AgentTable = forwardRef(function AgentTable(
-  { onAgentClick, filterNames, searchTerm = "" },
+  {
+    onAgentClick,
+    filterNames,
+    searchTerm = "",
+    initialCriteria = [],
+    limit,
+  },
   ref
 ) {
   const [agents, setAgents] = useState([]);
@@ -14,7 +20,11 @@ const AgentTable = forwardRef(function AgentTable(
   const [sortConfig, setSortConfig] = useState({ key: "name", direction: "asc" });
   const [ratings, setRatings] = useState({});
   const [criteria, setCriteria] = useState([]);
-  const [selectedCriteria, setSelectedCriteria] = useState([]);
+  const [selectedCriteria, setSelectedCriteria] = useState(initialCriteria);
+
+  useEffect(() => {
+    setSelectedCriteria(initialCriteria);
+  }, [initialCriteria]);
 
   useEffect(() => {
     async function loadData() {
@@ -123,6 +133,8 @@ const AgentTable = forwardRef(function AgentTable(
       })
     : agentsWithAverage;
 
+  const displayedAgents = limit ? sortedAgents.slice(0, limit) : sortedAgents;
+
   const renderStars = (rating) => {
     if (!rating) return "☆☆☆☆☆";
     const filled = "★".repeat(rating);
@@ -145,7 +157,7 @@ const AgentTable = forwardRef(function AgentTable(
       ...criteria.map((c) => c.name),
     ];
 
-    const rows = sortedAgents.map((agent) => {
+    const rows = displayedAgents.map((agent) => {
       const key = getAgentKey(agent.name);
       return [
         agent.name,
@@ -235,7 +247,7 @@ const AgentTable = forwardRef(function AgentTable(
           </tr>
         </thead>
         <tbody>
-          {sortedAgents.map((agent) => (
+          {displayedAgents.map((agent) => (
             <tr key={agent.name} className="odd:bg-white even:bg-background-blue/10 dark:odd:bg-gray-800 dark:even:bg-gray-700">
               <td className="px-4 py-2">
                 <button

--- a/website/src/pages/PersonaDetail.jsx
+++ b/website/src/pages/PersonaDetail.jsx
@@ -5,7 +5,6 @@ import AgentTable from "../components/AgentTable";
 function PersonaDetail({ onAgentClick }) {
   const { id } = useParams();
   const [persona, setPersona] = useState(null);
-  const [recommendedAgents, setRecommendedAgents] = useState([]);
 
   const renderMarkdown = (text) => ({
     __html: text.replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>"),
@@ -14,25 +13,22 @@ function PersonaDetail({ onAgentClick }) {
   useEffect(() => {
     async function loadPersona() {
       try {
-        const [personaRes, criteriaRes, ratingsRes] = await Promise.all([
+        const [personaRes, criteriaRes] = await Promise.all([
           fetch("/personas.json"),
           fetch("/persona_criteria.json"),
-          fetch("/persona_ratings.json"),
         ]);
-        if (!personaRes.ok || !criteriaRes.ok || !ratingsRes.ok) {
+        if (!personaRes.ok || !criteriaRes.ok) {
           throw new Error("Failed to fetch persona data");
         }
-        const [data, criteriaData, ratingsData] = await Promise.all([
+        const [data, criteriaData] = await Promise.all([
           personaRes.json(),
           criteriaRes.json(),
-          ratingsRes.json(),
         ]);
         const content = data[id];
         if (!content) return;
 
         const keyCriteriaStart = content.indexOf("### Key Criteria");
         const recommendedStart = content.indexOf("## Recommended Tools");
-        const whyStart = content.indexOf("## Why These Tools");
 
         const title = content
           .substring(0, content.indexOf("\n"))
@@ -50,53 +46,11 @@ function PersonaDetail({ onAgentClick }) {
           .filter((l) => l.startsWith("-"))
           .map((l) => l.replace(/^-\s*/, ""));
 
-        const recommendedText = content
-          .substring(recommendedStart, whyStart)
-          .trim();
-        const recommendedLines = recommendedText
-          .split("\n")
-          .slice(1)
-          .filter((l) => l.startsWith("-"))
-          .map((l) => l.replace(/^-\s*/, ""));
-        const recommendedNames = recommendedLines.map((line) => {
-          const match = line.match(/\*\*(.+?)\*\*/);
-          return match ? match[1] : line;
-        });
-
-        const whyText = content.substring(whyStart).trim();
-        const whyLines = whyText
-          .split("\n")
-          .slice(1)
-          .filter((l) => l.startsWith("-"))
-          .map((l) => l.replace(/^-\s*/, ""));
-
-        const personaCriteriaIds = criteriaData
+        const criteriaIds = criteriaData
           .filter((c) => c.personas.includes(title))
           .map((c) => c.id);
 
-        const getAgentKey = (name) =>
-          name?.toLowerCase().replace(/\s+/g, "_");
-
-        const sortedNames = [...recommendedNames]
-          .sort((a, b) => {
-            const aAvg =
-              personaCriteriaIds.reduce(
-                (sum, id) =>
-                  sum + (ratingsData[getAgentKey(a)]?.[id]?.rating || 0),
-                0
-              ) / personaCriteriaIds.length;
-            const bAvg =
-              personaCriteriaIds.reduce(
-                (sum, id) =>
-                  sum + (ratingsData[getAgentKey(b)]?.[id]?.rating || 0),
-                0
-              ) / personaCriteriaIds.length;
-            return bAvg - aAvg;
-          })
-          .slice(0, 4);
-
-        setPersona({ title, description, keyCriteria, whyLines });
-        setRecommendedAgents(sortedNames);
+        setPersona({ title, description, keyCriteria, criteriaIds });
       } catch (err) {
         console.error(err);
       }
@@ -116,34 +70,23 @@ function PersonaDetail({ onAgentClick }) {
       </Link>
       <div className="border border-background-blue dark:border-gray-700 p-4 mb-4">
         <h2 className="text-2xl font-archia mb-2">{persona.title}</h2>
-        <p className="mb-0">{persona.description}</p>
-      </div>
-      <div className="flex flex-col md:flex-row gap-4 mb-4">
-        <div className="border border-background-blue dark:border-gray-700 p-4 flex-1">
-          <h3 className="text-xl font-archia mb-2">Key Criteria</h3>
-          <ul className="list-disc pl-5">
-            {persona.keyCriteria.map((item) => (
-              <li
-                key={item}
-                dangerouslySetInnerHTML={renderMarkdown(item)}
-              />
-            ))}
-          </ul>
-        </div>
-        <div className="border border-background-blue dark:border-gray-700 p-4 flex-1">
-          <h3 className="text-xl font-archia mb-2">Why These Tools</h3>
-          <ul className="list-disc pl-5">
-            {persona.whyLines.map((line) => (
-              <li
-                key={line}
-                dangerouslySetInnerHTML={renderMarkdown(line)}
-              />
-            ))}
-          </ul>
-        </div>
+        <p className="mb-4">{persona.description}</p>
+        <h3 className="text-xl font-archia mb-2">Key Criteria</h3>
+        <ul className="list-disc pl-5">
+          {persona.keyCriteria.map((item) => (
+            <li
+              key={item}
+              dangerouslySetInnerHTML={renderMarkdown(item)}
+            />
+          ))}
+        </ul>
       </div>
       <h3 className="text-xl font-archia mb-2">Recommended Agents</h3>
-      <AgentTable onAgentClick={onAgentClick} filterNames={recommendedAgents} />
+      <AgentTable
+        onAgentClick={onAgentClick}
+        initialCriteria={persona.criteriaIds}
+        limit={5}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- dynamically filter agent recommendations based on persona criteria
- streamline persona detail page by merging description and key criteria into one box
- limit agent table to top five entries and remove static why-tools section

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ef42ae7548321a67ec3aa614d81d6