### PR TITLE
Improve OpenAI Codex agent profile and ratings

### DIFF
--- a/agents/OpenAI_Codex/agent_OpenAI_Codex.json
+++ b/agents/OpenAI_Codex/agent_OpenAI_Codex.json
@@ -1,11 +1,12 @@
 {
   "name": "OpenAI Codex",
-  "website": "https://openai.com/chatgpt",
+  "website": "https://chatgpt.com/codex",
   "developer": "OpenAI",
   "key_features": [
-    "Generates and edits code from natural language prompts within ChatGPT",
-    "Supports multiple programming languages",
-    "Provides conversational explanations and debugging assistance"
+    "Generates and edits code from conversational prompts inside ChatGPT",
+    "Executes snippets in a sandbox to validate output",
+    "Supports multiple programming languages and frameworks",
+    "Provides conversational explanations, refactoring suggestions, and debugging assistance"
   ],
   "supported_models": [
     "Integrated into ChatGPT; specific model names are not exposed"

--- a/agents/OpenAI_Codex/persona_ratings_openai_codex.json
+++ b/agents/OpenAI_Codex/persona_ratings_openai_codex.json
@@ -1,34 +1,34 @@
 {
   "automation_productivity": {
-    "rating": 3,
-    "reasoning": "Within ChatGPT, Codex can quickly generate or refactor snippets, but it cannot directly plug into external build or deployment pipelines."
+    "rating": 4,
+    "reasoning": "Codex accelerates day-to-day programming by drafting functions, refactoring code, and supplying context-aware suggestions that reduce manual typing, though integration with external build tools still requires user guidance."
   },
   "beginner_friendly_onboarding": {
-    "rating": 4,
-    "reasoning": "Using Codex inside ChatGPT requires no installation—users simply open a chat and describe the task."
+    "rating": 5,
+    "reasoning": "It runs entirely in the ChatGPT interface—no installations or configurations—and the conversational flow allows newcomers to ask for clarifications or examples as they learn."
   },
   "code_quality_testing": {
-    "rating": 2,
-    "reasoning": "Codex can suggest tests and point out potential issues, yet it cannot execute code or verify results automatically."
+    "rating": 3,
+    "reasoning": "Codex can generate unit tests, reason about edge cases, and execute small snippets in a sandbox to verify outputs, but cannot run full project test suites or guarantee correctness."
   },
   "codebase_comprehension": {
-    "rating": 3,
-    "reasoning": "It explains and edits snippets pasted into the conversation, though it lacks direct access to large repositories."
+    "rating": 4,
+    "reasoning": "The model explains pasted code, tracks context across a session, and suggests architectural improvements, although it lacks direct, large-scale repository indexing."
   },
   "creative_multimodal_exploration": {
-    "rating": 2,
-    "reasoning": "Interactions are primarily text-based, offering limited support for other modalities beyond natural language."
+    "rating": 3,
+    "reasoning": "While primarily text-based, Codex can produce visualizations or diagrams by generating code that renders charts or HTML, offering limited multimodal support."
   },
   "data_experimental_flexibility": {
-    "rating": 2,
-    "reasoning": "The assistant can draft analysis scripts but does not manage datasets or track experiment metadata."
+    "rating": 3,
+    "reasoning": "Using the built-in sandbox, Codex can run data analysis scripts and iterate on experiments, but it does not manage datasets or experiment tracking outside the chat."
   },
   "visual_no_code_development": {
-    "rating": 2,
-    "reasoning": "The chat interface reduces manual coding but lacks visual drag-and-drop tooling common in no-code platforms."
+    "rating": 3,
+    "reasoning": "Natural-language prompts reduce the need for manual coding and can scaffold simple interfaces, yet there is no true drag-and-drop builder."
   },
   "workflow_agent_orchestration": {
-    "rating": 1,
-    "reasoning": "Codex inside ChatGPT operates as a standalone helper without mechanisms to coordinate other agents or tools."
+    "rating": 2,
+    "reasoning": "Codex can call APIs or shell commands within the sandbox and produce scripts that automate tasks, but it lacks native orchestration of multiple external agents."
   }
 }

--- a/agents/OpenAI_Codex/profile.md
+++ b/agents/OpenAI_Codex/profile.md
@@ -1,17 +1,18 @@
 # OpenAI Codex
 
 ## Overview
-Within ChatGPT, OpenAI Codex acts as a conversational coding assistant that turns natural language prompts into executable code directly in the chat interface.
+Within ChatGPT, OpenAI Codex provides an interactive coding environment that turns natural language prompts into runnable code and explanations inside the chat interface.
 
 ## Key Information
 - **Developer:** OpenAI
-- **Website:** [https://openai.com/chatgpt](https://openai.com/chatgpt)
+- **Website:** [https://chatgpt.com/codex](https://chatgpt.com/codex)
 - **Pricing:** Included with ChatGPT Plus and enterprise plans
 
 ## Key Features
-- Generates and edits code through conversational prompts
-- Supports multiple programming languages
-- Provides inline explanations and debugging help inside ChatGPT
+- Generates and edits code from conversational prompts
+- Executes snippets in a sandbox to validate output
+- Supports multiple programming languages and frameworks
+- Provides inline explanations, refactoring suggestions, and debugging help inside ChatGPT
 
 ## Supported Models
 - Integrated into ChatGPT; specific model names are not exposed
@@ -23,8 +24,8 @@ Within ChatGPT, OpenAI Codex acts as a conversational coding assistant that turn
 
 ## Qualitative Assessment
 - **Ease of Use:** High – accessible through the ChatGPT interface with no setup.
-- **Documentation Quality:** Moderate – basic help center guidance.
-- **Onboarding Experience:** High – users simply start a ChatGPT conversation.
+- **Documentation Quality:** Moderate – official help articles and community examples.
+- **Onboarding Experience:** High – users simply start a ChatGPT conversation or enable the feature.
 
 ## Missing Data
 OpenAI has not published benchmark results or detailed resource metrics for Codex features within ChatGPT as of May 2025.

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -156,12 +156,13 @@
   },
   {
     "name": "OpenAI Codex",
-    "website": "https://openai.com/chatgpt",
+    "website": "https://chatgpt.com/codex",
     "developer": "OpenAI",
     "key_features": [
-      "Generates and edits code through conversational prompts",
-      "Supports multiple programming languages",
-      "Provides inline explanations and debugging help inside ChatGPT"
+      "Generates and edits code from conversational prompts",
+      "Executes snippets in a sandbox to validate output",
+      "Supports multiple programming languages and frameworks",
+      "Provides inline explanations, refactoring suggestions, and debugging help inside ChatGPT"
     ],
     "supported_models": [
       "Integrated into ChatGPT; specific model names are not exposed"


### PR DESCRIPTION
## Summary
- Update OpenAI Codex profile with new chatgpt.com/codex link and richer feature list.
- Refresh persona ratings, boosting scores for code quality, codebase comprehension and other criteria with expanded reasoning.
- Align agent JSON and public agents listing to reflect new website and capabilities.

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689efa1faff08321b06284cbf22e3f6d