### PR TITLE
Add n8n agent profile and website data

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The following agents have been profiled in this repository:
 - chat.z.ai (`agents/chat.z.ai`)
 - Perplexity Labs (`agents/Perplexity_Labs`)
 - v0.app (`agents/v0.app`)
+- n8n (`agents/n8n`)
 - Zapier (`agents/Zapier`)
 
 ### Agent Frameworks

--- a/agents/n8n/agent_n8n.json
+++ b/agents/n8n/agent_n8n.json
@@ -1,0 +1,21 @@
+{
+  "name": "n8n",
+  "website": "https://n8n.io/",
+  "developer": "n8n GmbH",
+  "key_features": [
+    "Drag-and-drop workflow builder with 400+ integrations and templates",
+    "AI-native platform for building LangChain-based agent workflows",
+    "Extendable with JavaScript or Python and npm packages",
+    "Self-host or use n8n Cloud with enterprise features"
+  ],
+  "supported_models": [
+    "Integrates with OpenAI, Anthropic, Google Gemini and other LangChain-compatible models"
+  ],
+  "pricing_model": "Fair-code licensed; free self-hosting with paid cloud plans starting around $20/month",
+  "benchmarks": {
+    "swe_bench_score": null,
+    "task_success_rate": null,
+    "resource_usage": ""
+  },
+  "description": "n8n is an open-source workflow automation platform that combines a visual editor with optional code, enabling users to orchestrate APIs, databases, and AI models."
+}

--- a/agents/n8n/persona_ratings_n8n.json
+++ b/agents/n8n/persona_ratings_n8n.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 5,
+    "reasoning": "Visual workflows with 400+ integrations automate complex processes and repetitive tasks."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Cloud offering and templates ease setup but building workflows still needs some technical understanding."
+  },
+  "code_quality_testing": {
+    "rating": 1,
+    "reasoning": "Designed for automation rather than code analysis or testing features."
+  },
+  "codebase_comprehension": {
+    "rating": 1,
+    "reasoning": "Does not focus on navigating or understanding software codebases."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 2,
+    "reasoning": "AI nodes can generate text or images via external models but multimodal tools are limited."
+  },
+  "data_experimental_flexibility": {
+    "rating": 4,
+    "reasoning": "Supports custom scripting and diverse APIs, enabling flexible data workflows."
+  },
+  "visual_no_code_development": {
+    "rating": 5,
+    "reasoning": "Drag-and-drop editor enables building workflows without writing code."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 5,
+    "reasoning": "Connects multiple services and LLMs into orchestrated multi-step processes."
+  }
+}

--- a/agents/n8n/profile.md
+++ b/agents/n8n/profile.md
@@ -1,0 +1,34 @@
+# n8n
+
+## Overview
+
+n8n is an open-source workflow automation platform that combines the flexibility of code with a visual editor. It lets teams connect APIs, databases, and AI models to build custom automations.
+
+## Key Information
+
+- **Developer:** n8n GmbH
+- **Website:** [https://n8n.io/](https://n8n.io/)
+- **Pricing:** Fair-code licensed; free self-hosting with paid cloud plans available
+
+## Key Features
+
+- **Visual workflow builder:** Drag-and-drop node-based editor with 400+ integrations and templates.
+- **AI-native:** Build LangChain-based agent workflows and connect to various LLM providers.
+- **Extend with code:** Write JavaScript or Python inside nodes and install npm packages.
+- **Self-host or cloud:** Run on your own infrastructure or use n8n Cloud with enterprise features.
+
+## Supported Models
+
+- Integrates with OpenAI, Anthropic, Google Gemini and other LangChain-compatible models.
+
+## Benchmarks
+
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+
+- **Ease of Use:** Not available
+- **Documentation Quality:** Not available
+- **Onboarding Experience:** Not available

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -1145,5 +1145,26 @@
       "task_success_rate": null,
       "resource_usage": null
     }
+  },
+  {
+    "name": "n8n",
+    "website": "https://n8n.io/",
+    "developer": "n8n GmbH",
+    "key_features": [
+      "Drag-and-drop workflow builder with 400+ integrations and templates",
+      "AI-native platform for building LangChain-based agent workflows",
+      "Extendable with JavaScript or Python and npm packages",
+      "Self-host or use n8n Cloud with enterprise features"
+    ],
+    "supported_models": [
+      "Integrates with OpenAI, Anthropic, Google Gemini and other LangChain-compatible models"
+    ],
+    "pricing_model": "Fair-code licensed; free self-hosting with paid cloud plans starting around $20/month",
+    "benchmarks": {
+      "swe_bench_score": null,
+      "task_success_rate": null,
+      "resource_usage": ""
+    },
+    "description": "n8n is an open-source workflow automation platform that combines a visual editor with optional code, enabling users to orchestrate APIs, databases, and AI models."
   }
 ]

--- a/website/public/persona_ratings.json
+++ b/website/public/persona_ratings.json
@@ -1562,5 +1562,39 @@
       "rating": 4,
       "reasoning": "Handles multi-step processes with branching, scheduling, and AI-driven actions, providing strong orchestration capabilities."
     }
+  },
+  "n8n": {
+    "automation_productivity": {
+      "rating": 5,
+      "reasoning": "Visual workflows with 400+ integrations automate complex processes and repetitive tasks."
+    },
+    "beginner_friendly_onboarding": {
+      "rating": 3,
+      "reasoning": "Cloud offering and templates ease setup but building workflows still needs some technical understanding."
+    },
+    "code_quality_testing": {
+      "rating": 1,
+      "reasoning": "Designed for automation rather than code analysis or testing features."
+    },
+    "codebase_comprehension": {
+      "rating": 1,
+      "reasoning": "Does not focus on navigating or understanding software codebases."
+    },
+    "creative_multimodal_exploration": {
+      "rating": 2,
+      "reasoning": "AI nodes can generate text or images via external models but multimodal tools are limited."
+    },
+    "data_experimental_flexibility": {
+      "rating": 4,
+      "reasoning": "Supports custom scripting and diverse APIs, enabling flexible data workflows."
+    },
+    "visual_no_code_development": {
+      "rating": 5,
+      "reasoning": "Drag-and-drop editor enables building workflows without writing code."
+    },
+    "workflow_agent_orchestration": {
+      "rating": 5,
+      "reasoning": "Connects multiple services and LLMs into orchestrated multi-step processes."
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add n8n agent profile with features, model support, and pricing
- record persona ratings for n8n
- integrate n8n into website data and README list

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689efd8422688321b2b0f63e3c9868aa