### PR TITLE
Add Lindy agent profile and website entry

### DIFF
--- a/agents/Lindy/agent_Lindy.json
+++ b/agents/Lindy/agent_Lindy.json
@@ -1,0 +1,27 @@
+{
+  "name": "Lindy",
+  "website": "https://www.lindy.ai/",
+  "developer": "Lindy Inc.",
+  "key_features": [
+    "Autonomous AI assistant for operations and administrative tasks",
+    "Integrates with email, calendars, and business apps to automate workflows",
+    "Natural language interface for delegating tasks",
+    "Learns and adapts to user preferences over time",
+    "Handles multi-step processes across web applications"
+  ],
+  "supported_models": [
+    "OpenAI GPT-4",
+    "Anthropic Claude",
+    "Proprietary Lindy models"
+  ],
+  "pricing_model": "Enterprise and team plans; contact for pricing (beta access)",
+  "description": "Lindy is an AI-powered digital worker that performs administrative and operational tasks by operating software through natural language instructions.",
+  "benchmarks": {
+    "swe_bench_score": null,
+    "swe_bench_source": null,
+    "terminal_bench_score": null,
+    "terminal_bench_source": null,
+    "task_success_rate": null,
+    "resource_usage": null
+  }
+}

--- a/agents/Lindy/persona_ratings_lindy.json
+++ b/agents/Lindy/persona_ratings_lindy.json
@@ -1,0 +1,34 @@
+{
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Sign-up and onboarding are straightforward but currently oriented toward beta and enterprise users, limiting immediate accessibility."
+  },
+  "visual_no_code_development": {
+    "rating": 2,
+    "reasoning": "Provides a web interface for configuring workflows but lacks a full drag-and-drop builder for complex applications."
+  },
+  "automation_productivity": {
+    "rating": 4,
+    "reasoning": "Focuses on automating administrative tasks like email and scheduling, significantly reducing manual workload."
+  },
+  "data_experimental_flexibility": {
+    "rating": 2,
+    "reasoning": "Integrations cover common business apps but offer limited tooling for data science experimentation."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Capable of handling multi-step processes across services, though orchestration options are less customizable than dedicated frameworks."
+  },
+  "codebase_comprehension": {
+    "rating": 1,
+    "reasoning": "Designed for operational tasks rather than understanding or navigating source code."
+  },
+  "code_quality_testing": {
+    "rating": 1,
+    "reasoning": "Does not provide features for testing or improving code quality."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 2,
+    "reasoning": "Supports natural language interactions but offers limited built-in multimodal creativity tools."
+  }
+}

--- a/agents/Lindy/profile.md
+++ b/agents/Lindy/profile.md
@@ -1,0 +1,37 @@
+# Lindy
+
+## Overview
+
+Lindy is an AI-powered digital worker designed to handle operational and administrative tasks. Users delegate work in natural language, and Lindy executes multi-step workflows across web applications, learning preferences over time.
+
+## Key Information
+
+- **Developer:** Lindy Inc.
+- **Website:** [https://www.lindy.ai/](https://www.lindy.ai/)
+- **Pricing:** Enterprise and team plans; contact for pricing (beta access)
+
+## Key Features
+
+- **Autonomous Operations:** Performs tasks like email handling, scheduling, and data entry.
+- **App Integrations:** Connects with business tools such as Gmail, Google Calendar, and Slack.
+- **Natural Language Delegation:** Users describe goals in plain language to initiate workflows.
+- **Adaptive Learning:** Learns user preferences and adapts to individual workflows.
+- **Multi-Step Execution:** Handles sequences of actions across multiple web applications.
+
+## Supported Models
+
+- OpenAI GPT-4
+- Anthropic Claude
+- Proprietary Lindy models
+
+## Benchmarks
+
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+
+- **Ease of Use:** Designed for business users with minimal technical setup.
+- **Documentation Quality:** Limited public documentation due to beta status.
+- **Onboarding Experience:** Streamlined, though access may require joining a waitlist.

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -192,9 +192,9 @@
     ],
     "pricing_model": "Cloud-based platform with a free tier and enterprise options.",
     "benchmarks": {
-      "terminal_bench_score": "42.5% \u00b1 0.8",
+      "terminal_bench_score": "42.5% ± 0.8",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
-      "terminal_bench_score_from_leaderboard": "42.5% \u00b1 0.8"
+      "terminal_bench_score_from_leaderboard": "42.5% ± 0.8"
     },
     "description": "Letta is a platform for building stateful AI agents that retain long-term memory and expose their capabilities through REST APIs. Built on MemGPT, it offers tools to visualize agent reasoning and integrate custom tools across multiple frameworks."
   },
@@ -217,11 +217,11 @@
     ],
     "pricing_model": "Requires an OpenAI API key or a paid OpenAI account (Plus/Pro).",
     "benchmarks": {
-      "terminal_bench_score": "20.0% \u00b1 1.5",
+      "terminal_bench_score": "20.0% ± 1.5",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.2,
       "resource_usage": "Runs locally; resource usage depends on chosen model",
-      "terminal_bench_score_from_leaderboard": "20.0% \u00b1 1.5"
+      "terminal_bench_score_from_leaderboard": "20.0% ± 1.5"
     },
     "description": "Codex CLI is an open-source coding agent from OpenAI that runs locally on your computer and interacts with your terminal."
   },
@@ -346,7 +346,7 @@
       "task_success_rate": null,
       "resource_usage": ""
     },
-    "description": "Amazon CodeWhisperer is a machine learning (ML)\u2013powered service that helps improve developer productivity by generating code recommendations based on their comments in natural language and code in the integrated development environment (IDE). It is in the process of being integrated into Amazon Q Developer."
+    "description": "Amazon CodeWhisperer is a machine learning (ML)–powered service that helps improve developer productivity by generating code recommendations based on their comments in natural language and code in the integrated development environment (IDE). It is in the process of being integrated into Amazon Q Developer."
   },
   {
     "name": "Tabnine",
@@ -668,11 +668,11 @@
     "benchmarks": {
       "swe_bench_score": 49,
       "swe_bench_source": "https://www.anthropic.com/research/swe-bench-sonnet",
-      "terminal_bench_score": "43.2% \u00b1 1.3",
+      "terminal_bench_score": "43.2% ± 1.3",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.432,
       "resource_usage": "Not publicly documented",
-      "terminal_bench_score_from_leaderboard": "43.2% \u00b1 1.3"
+      "terminal_bench_score_from_leaderboard": "43.2% ± 1.3"
     },
     "description": "Terminal-based coding assistant that understands your codebase and handles git workflows through natural language commands."
   },
@@ -692,11 +692,11 @@
     ],
     "pricing_model": "Open-source under the MIT License; free for self-hosting with optional paid hosting via Daytona",
     "benchmarks": {
-      "terminal_bench_score": "41.3% \u00b1 0.7",
+      "terminal_bench_score": "41.3% ± 0.7",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.413,
       "resource_usage": "Not publicly documented; depends on hosting environment and model",
-      "terminal_bench_score_from_leaderboard": "41.3% \u00b1 0.7"
+      "terminal_bench_score_from_leaderboard": "41.3% ± 0.7"
     },
     "description": "OpenHands is an open-source AI coding agent and framework from Daytona that aims to let agents perform end-to-end software development tasks."
   },
@@ -856,11 +856,11 @@
     ],
     "pricing_model": "Open-source",
     "benchmarks": {
-      "terminal_bench_score": "42.0% \u00b1 1.3",
+      "terminal_bench_score": "42.0% ± 1.3",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.42,
       "resource_usage": "Depends on local hardware and model; no public metrics",
-      "terminal_bench_score_from_leaderboard": "42.0% \u00b1 1.3"
+      "terminal_bench_score_from_leaderboard": "42.0% ± 1.3"
     },
     "description": "Goose is an open-source, on-machine AI agent from Block that automates engineering tasks autonomously."
   },
@@ -905,7 +905,7 @@
     ],
     "pricing_model": "Research project, likely free to use.",
     "benchmarks": {
-      "terminal_bench_score": "39.9% \u00b1 1.0",
+      "terminal_bench_score": "39.9% ± 1.0",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.399,
       "resource_usage": "Not publicly documented; depends on remote environment and model"
@@ -984,7 +984,7 @@
       "task_success_rate": 0.52,
       "resource_usage": "Not publicly documented; depends on local hardware and active agents",
       "swe_bench_score": "71%",
-      "terminal_bench_score_from_leaderboard": "52.0% \u00b1 1.0"
+      "terminal_bench_score_from_leaderboard": "52.0% ± 1.0"
     },
     "description": "Warp is an agentic development environment and terminal that enables fast, native interactions with multiple AI agents across the development workflow."
   },
@@ -1136,7 +1136,34 @@
     ],
     "pricing_model": "Freemium with paid plans starting at $19.99/month",
     "description": "Zapier is a web-based automation service that connects apps and automates workflows with a visual builder and optional AI features.",
-    "long_description": "Zapier lets users build \"Zaps\" that trigger actions across thousands of services. Its drag-and-drop interface, code steps, and AI Actions allow both non\u2011technical and technical users to automate complex multi-step processes without managing infrastructure.",
+    "long_description": "Zapier lets users build \"Zaps\" that trigger actions across thousands of services. Its drag-and-drop interface, code steps, and AI Actions allow both non‑technical and technical users to automate complex multi-step processes without managing infrastructure.",
+    "benchmarks": {
+      "swe_bench_score": null,
+      "swe_bench_source": null,
+      "terminal_bench_score": null,
+      "terminal_bench_source": null,
+      "task_success_rate": null,
+      "resource_usage": null
+    }
+  },
+  {
+    "name": "Lindy",
+    "website": "https://www.lindy.ai/",
+    "developer": "Lindy Inc.",
+    "key_features": [
+      "Autonomous AI assistant for operations and administrative tasks",
+      "Integrates with email, calendars, and business apps to automate workflows",
+      "Natural language interface for delegating tasks",
+      "Learns and adapts to user preferences over time",
+      "Handles multi-step processes across web applications"
+    ],
+    "supported_models": [
+      "OpenAI GPT-4",
+      "Anthropic Claude",
+      "Proprietary Lindy models"
+    ],
+    "pricing_model": "Enterprise and team plans; contact for pricing (beta access)",
+    "description": "Lindy is an AI-powered digital worker that performs administrative and operational tasks by operating software through natural language instructions.",
     "benchmarks": {
       "swe_bench_score": null,
       "swe_bench_source": null,

--- a/website/public/persona_ratings.json
+++ b/website/public/persona_ratings.json
@@ -1026,7 +1026,7 @@
     },
     "beginner_friendly_onboarding": {
       "rating": 4,
-      "reasoning": "Using Codex inside ChatGPT requires no installation\u2014users simply open a chat and describe the task."
+      "reasoning": "Using Codex inside ChatGPT requires no installation—users simply open a chat and describe the task."
     },
     "code_quality_testing": {
       "rating": 2,
@@ -1561,6 +1561,40 @@
     "workflow_agent_orchestration": {
       "rating": 4,
       "reasoning": "Handles multi-step processes with branching, scheduling, and AI-driven actions, providing strong orchestration capabilities."
+    }
+  },
+  "lindy": {
+    "beginner_friendly_onboarding": {
+      "rating": 3,
+      "reasoning": "Sign-up and onboarding are straightforward but currently oriented toward beta and enterprise users, limiting immediate accessibility."
+    },
+    "visual_no_code_development": {
+      "rating": 2,
+      "reasoning": "Provides a web interface for configuring workflows but lacks a full drag-and-drop builder for complex applications."
+    },
+    "automation_productivity": {
+      "rating": 4,
+      "reasoning": "Focuses on automating administrative tasks like email and scheduling, significantly reducing manual workload."
+    },
+    "data_experimental_flexibility": {
+      "rating": 2,
+      "reasoning": "Integrations cover common business apps but offer limited tooling for data science experimentation."
+    },
+    "workflow_agent_orchestration": {
+      "rating": 3,
+      "reasoning": "Capable of handling multi-step processes across services, though orchestration options are less customizable than dedicated frameworks."
+    },
+    "codebase_comprehension": {
+      "rating": 1,
+      "reasoning": "Designed for operational tasks rather than understanding or navigating source code."
+    },
+    "code_quality_testing": {
+      "rating": 1,
+      "reasoning": "Does not provide features for testing or improving code quality."
+    },
+    "creative_multimodal_exploration": {
+      "rating": 2,
+      "reasoning": "Supports natural language interactions but offers limited built-in multimodal creativity tools."
     }
   }
 }


### PR DESCRIPTION
## Summary
- add Lindy AI agent profile, metadata, and persona ratings
- include Lindy in website agents and persona ratings datasets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689efe1b4d9c8321b7782034f6e55079