### PR TITLE
Hide website column in AgentTable UI

### DIFF
--- a/website/src/components/AgentTable.jsx
+++ b/website/src/components/AgentTable.jsx
@@ -7,7 +7,6 @@ import {
 
 const AgentTable = forwardRef(function AgentTable(
   {
-    onAgentClick,
     filterNames,
     searchTerm = "",
     initialCriteria = [],
@@ -219,7 +218,6 @@ const AgentTable = forwardRef(function AgentTable(
         <thead className="bg-background-blue text-white dark:bg-stratos-blue">
           <tr>
             <th className="px-4 py-2 font-archia">Name</th>
-            <th className="px-4 py-2 font-archia">Website</th>
             <th className="px-4 py-2 font-archia">Developer</th>
             <th className="px-4 py-2 font-archia">Pricing</th>
             {criteria.map((c) => (
@@ -250,22 +248,13 @@ const AgentTable = forwardRef(function AgentTable(
           {displayedAgents.map((agent) => (
             <tr key={agent.name} className="odd:bg-white even:bg-background-blue/10 dark:odd:bg-gray-800 dark:even:bg-gray-700">
               <td className="px-4 py-2">
-                <button
-                  type="button"
-                  onClick={() => onAgentClick(agent)}
-                  className="underline text-left"
-                >
-                  {agent.name}
-                </button>
-              </td>
-              <td className="px-4 py-2">
                 <a
                   href={agent.website}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="underline"
                 >
-                  {agent.website}
+                  {agent.name}
                 </a>
               </td>
               <td className="px-4 py-2">{agent.developer}</td>


### PR DESCRIPTION
## Summary
- Remove Website column from AgentTable display, keeping it only in exports
- Link agent names directly to their websites for cleaner layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f027129f88321bb7959b5bab13a74