### PR TITLE
Add OpenAI Agents SDK (Swarm) research

### DIFF
--- a/agents/OpenAI_Agents_SDK_Swarm/agent_OpenAI_Agents_SDK_Swarm.json
+++ b/agents/OpenAI_Agents_SDK_Swarm/agent_OpenAI_Agents_SDK_Swarm.json
@@ -1,0 +1,27 @@
+{
+  "name": "OpenAI Agents SDK (Swarm)",
+  "website": "https://openai.github.io/openai-agents-python/",
+  "developer": "OpenAI",
+  "key_features": [
+    "Lightweight Python framework for multi-agent workflows",
+    "Handoffs for transferring control between agents",
+    "Guardrails for input and output validation",
+    "Session management for conversation history",
+    "Tracing UI for debugging agent runs",
+    "Provider-agnostic design supporting 100+ LLMs"
+  ],
+  "supported_models": [
+    "OpenAI GPT-4.1",
+    "OpenAI GPT-4o",
+    "100+ LLMs via LiteLLM"
+  ],
+  "pricing_model": "Open-source MIT license; pay for underlying model and compute usage.",
+  "description": "OpenAI’s official agent SDK, formerly known as Swarm, providing minimal components to build custom LLM agents.",
+  "long_description": "The Agents SDK offers agents, tools, handoffs, guardrails, sessions, and tracing to compose autonomous multi-agent applications. It integrates with OpenAI Responses and Chat Completions APIs and other models through LiteLLM.",
+  "benchmarks": {
+    "swe_bench_score": null,
+    "swe_bench_source": null,
+    "task_success_rate": null,
+    "resource_usage": null
+  }
+}

--- a/agents/OpenAI_Agents_SDK_Swarm/persona_ratings_openai_agents_sdk_swarm.json
+++ b/agents/OpenAI_Agents_SDK_Swarm/persona_ratings_openai_agents_sdk_swarm.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 4,
+    "reasoning": "The SDK enables developers to automate multi-step workflows with composable agents and tools."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 2,
+    "reasoning": "It targets Python developers and requires manual setup from source."
+  },
+  "code_quality_testing": {
+    "rating": 2,
+    "reasoning": "Quality and testing depend on user-implemented tools; the SDK offers no built-in code analysis."
+  },
+  "codebase_comprehension": {
+    "rating": 2,
+    "reasoning": "While agents can be configured to read repositories, there is no dedicated code exploration capability."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 2,
+    "reasoning": "Multimodal support depends on the models and tools chosen; the core library is text-focused."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "The framework can orchestrate data analysis via custom tools but provides no native notebooks or datasets."
+  },
+  "visual_no_code_development": {
+    "rating": 1,
+    "reasoning": "Developers must write Python code; there is no visual or drag-and-drop interface."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 5,
+    "reasoning": "Agents, handoffs, guardrails, and tracing offer strong support for complex multi-agent orchestration."
+  }
+}

--- a/agents/OpenAI_Agents_SDK_Swarm/profile.md
+++ b/agents/OpenAI_Agents_SDK_Swarm/profile.md
@@ -1,0 +1,37 @@
+# OpenAI Agents SDK (Swarm)
+
+## Overview
+
+OpenAI Agents SDK (formerly Swarm) is a lightweight Python framework for building multi-agent applications. It provides minimalist building blocks—agents, tools, handoffs, and guardrails—to orchestrate autonomous LLM workflows.
+
+## Key Information
+
+- **Developer:** OpenAI
+- **Website:** [https://openai.github.io/openai-agents-python/](https://openai.github.io/openai-agents-python/)
+- **Pricing:** Open-source MIT license; cost is usage of underlying model APIs.
+
+## Key Features
+
+- **Multi-agent orchestration:** Define agents with instructions and tools, then pass control via handoffs.
+- **Guardrails:** Configurable input and output validation for safer agent behavior.
+- **Session management:** Automatic conversation history across runs.
+- **Tracing UI:** Built-in tracing and debugging for agent workflows.
+- **Provider-agnostic:** Works with OpenAI models and 100+ other LLMs via LiteLLM.
+
+## Supported Models
+
+Supports OpenAI Responses and Chat Completions APIs, including GPT-4.1 and GPT-4o, and over 100 other models through LiteLLM.
+
+## Pricing Model
+
+Released under the MIT license and free to use; users pay only for the model and infrastructure resources their agents consume.
+
+## Benchmarks
+
+No public benchmark scores are available.
+
+## Qualitative Assessment
+
+- **Ease of Use:** 3/5 – Minimalistic API but requires Python development.
+- **Documentation Quality:** 4/5 – Comprehensive README and docs site.
+- **Onboarding Experience:** Requires Python environment; examples and quickstart guide are provided.

--- a/missing_entries.json
+++ b/missing_entries.json
@@ -3,7 +3,8 @@
     "Name": "OpenAI Agents SDK (Swarm)",
     "Website": "https://openai.github.io/openai-agents-python/",
     "Description": "OpenAI’s official agent SDK, formerly known as Swarm, which provides minimalist building blocks (agents, tools, handoffs, guardrails) for creating autonomous LLM agents with built-in support for OpenAI models and function calling.",
-    "Reason for inclusion": "As a production-ready toolkit from OpenAI for autonomous agents, it represents a key developer framework in 2025 that was not yet covered in the original list."
+    "Reason for inclusion": "As a production-ready toolkit from OpenAI for autonomous agents, it represents a key developer framework in 2025 that was not yet covered in the original list.",
+    "status": "added"
   },
   {
     "Name": "SuperAGI",


### PR DESCRIPTION
## Summary
- add research profile for OpenAI Agents SDK (Swarm)
- record persona ratings for the SDK
- mark OpenAI Agents SDK (Swarm) as added in missing_entries.json

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f19fff2fc8321a3213947e2f8aa13