### PR TITLE
Add Fixie.ai agent research

### DIFF
--- a/agents/Fixie.ai/agent_Fixie.ai.json
+++ b/agents/Fixie.ai/agent_Fixie.ai.json
@@ -1,0 +1,23 @@
+{
+  "name": "Fixie.ai",
+  "website": "https://fixie.ai/",
+  "developer": "Fixie",
+  "key_features": [
+    "Hosted agent runtime with API and chat integrations",
+    "Skill and knowledge base system for external data and APIs",
+    "Marketplace of pre-built skills and agents",
+    "Supports multiple LLM backends",
+    "Enterprise security and deployment options"
+  ],
+  "supported_models": [
+    "OpenAI GPT-4 and GPT-3.5",
+    "Anthropic Claude",
+    "Other LLMs via pluggable backends"
+  ],
+  "pricing_model": "Contact for pricing (free developer tier available)",
+  "benchmarks": {
+    "swe_bench_score": null,
+    "task_success_rate": null,
+    "resource_usage": ""
+  }
+}

--- a/agents/Fixie.ai/persona_ratings_fixie.ai.json
+++ b/agents/Fixie.ai/persona_ratings_fixie.ai.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 4,
+    "reasoning": "Hosted agents and skill integrations allow Fixie.ai to automate enterprise workflows across tools."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "SDKs and examples help new users, but building skills typically requires developer experience."
+  },
+  "code_quality_testing": {
+    "rating": 2,
+    "reasoning": "Platform is not oriented toward software testing or code quality beyond executing agent code."
+  },
+  "codebase_comprehension": {
+    "rating": 2,
+    "reasoning": "While agents can access repositories via connectors, the service is not primarily for code understanding."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Agents can combine text, APIs, and data sources, enabling some multimodal interactions."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Connectors to knowledge bases and APIs offer data flexibility, though experiment tracking is limited."
+  },
+  "visual_no_code_development": {
+    "rating": 2,
+    "reasoning": "Fixie.ai provides a dashboard but primarily expects code-based agent creation."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 4,
+    "reasoning": "The platform orchestrates agents and skills, supporting complex multi-step workflows."
+  }
+}

--- a/agents/Fixie.ai/profile.md
+++ b/agents/Fixie.ai/profile.md
@@ -1,0 +1,37 @@
+# Fixie.ai
+
+## Overview
+
+Fixie.ai is a platform for building and hosting AI agents that can connect to external tools and data sources. It aims to help developers and organizations deploy conversational assistants and workflow automations powered by large language models.
+
+## Key Information
+
+- **Developer:** Fixie
+- **Website:** [https://fixie.ai/](https://fixie.ai/)
+- **Pricing:** Contact for pricing (free developer tier available)
+
+## Key Features
+
+- Hosted agent runtime with API and chat integrations (e.g., Slack, Teams)
+- Skill and knowledge base system for connecting to external data or APIs
+- Marketplace of pre-built skills and agents for rapid composition
+- Support for multiple LLM backends and retrieval-Augmented generation
+- Enterprise-oriented security and deployment options
+
+## Supported Models
+
+- OpenAI GPT-4 and GPT-3.5
+- Anthropic Claude models
+- Other LLMs via pluggable backends
+
+## Benchmarks
+
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+
+- **Ease of Use:** Moderate; offers SDKs and a hosted runtime but targets developers
+- **Documentation Quality:** Good; provides guides and API references for building agents and skills
+- **Onboarding Experience:** Guided tutorials and examples streamline initial agent creation

--- a/missing_entries.json
+++ b/missing_entries.json
@@ -39,7 +39,8 @@
     "Name": "Fixie.ai",
     "Website": "https://fixie.ai/",
     "Description": "A platform for building and hosting AI agents that connect to external tools and data sources. It provides a marketplace of ready-made agent skills and a framework for developers to create custom agents for enterprise workflows.",
-    "Reason for inclusion": "Fixie.ai is a notable commercial solution for agent-based automation, illustrating the emerging ecosystem of cloud platforms for customized AI assistants and workflow automation."
+    "Reason for inclusion": "Fixie.ai is a notable commercial solution for agent-based automation, illustrating the emerging ecosystem of cloud platforms for customized AI assistants and workflow automation.",
+    "status": "added"
   },
   {
     "Name": "Semantic Kernel",


### PR DESCRIPTION
## Summary
- add initial research profile for Fixie.ai
- record agent and persona ratings for Fixie.ai
- mark Fixie.ai as added in missing_entries.json

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open 'package.json')
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f1a7b358c8321ab1505e645e4d0b1