### PR TITLE
Add AgentVerse research entry

### DIFF
--- a/agents/AgentVerse/agent_AgentVerse.json
+++ b/agents/AgentVerse/agent_AgentVerse.json
@@ -1,0 +1,22 @@
+{
+  "name": "AgentVerse",
+  "website": "https://github.com/OpenBMB/AgentVerse",
+  "developer": "OpenBMB",
+  "key_features": [
+    "Task-solving framework for collaborative multi-agent systems",
+    "Simulation framework for multi-agent environments",
+    "Supports local LLMs such as LLaMA and Vicuna",
+    "Demos including NLP Classroom, Prisoner's Dilemma, and Software Design",
+    "Extensible configuration of agents and environments"
+  ],
+  "supported_models": [
+    "OpenAI models",
+    "Local LLMs like LLaMA and Vicuna"
+  ],
+  "pricing_model": "Free and open-source (Apache 2.0 license)",
+  "benchmarks": {
+    "swe_bench_score": null,
+    "task_success_rate": null,
+    "resource_usage": ""
+  }
+}

--- a/agents/AgentVerse/persona_ratings_agentverse.json
+++ b/agents/AgentVerse/persona_ratings_agentverse.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "The task-solving framework can automate collaborative tasks, but it requires substantial setup and customization."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 2,
+    "reasoning": "Installation and configuration rely on Python skills, and documentation is still maturing."
+  },
+  "code_quality_testing": {
+    "rating": 2,
+    "reasoning": "While demos include software development roles, the framework does not focus on integrated testing or quality tools."
+  },
+  "codebase_comprehension": {
+    "rating": 1,
+    "reasoning": "AgentVerse targets multi-agent coordination rather than understanding existing codebases."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 2,
+    "reasoning": "Some simulation demos involve interactive environments, but multimodal capabilities are limited."
+  },
+  "data_experimental_flexibility": {
+    "rating": 4,
+    "reasoning": "Open-source design and support for both OpenAI and local models allow flexible experimentation across scenarios."
+  },
+  "visual_no_code_development": {
+    "rating": 1,
+    "reasoning": "Configuration is code-driven with no visual or no-code interface."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 5,
+    "reasoning": "Orchestrating multiple agents and roles is the core strength of the platform."
+  }
+}

--- a/agents/AgentVerse/profile.md
+++ b/agents/AgentVerse/profile.md
@@ -1,0 +1,36 @@
+# AgentVerse
+
+## Overview
+
+AgentVerse is an open-source research platform for multi-agent collaboration and simulations. It enables developers to configure multiple LLM-based agents with different roles that interact to solve tasks or model complex environments.
+
+## Key Information
+
+- **Developer:** OpenBMB
+- **Website:** [https://github.com/OpenBMB/AgentVerse](https://github.com/OpenBMB/AgentVerse)
+- **Pricing:** Free and open-source (Apache 2.0 license)
+
+## Key Features
+
+- Task-solving framework for assembling cooperative multi-agent systems
+- Simulation framework for creating custom environments and observing agent behaviors
+- Supports local LLMs such as LLaMA and Vicuna as well as OpenAI models
+- Includes demos like NLP Classroom, Prisoner's Dilemma, Software Design, and Database Administrator
+- Extensible configuration for agents and environments
+
+## Supported Models
+
+- OpenAI models
+- Local LLMs (e.g., LLaMA, Vicuna)
+
+## Benchmarks
+
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+
+- **Ease of Use:** Moderate; setup and configuration require Python and command-line experience.
+- **Documentation Quality:** Moderate; README includes examples but formal documentation is still being developed.
+- **Onboarding Experience:** Developer-oriented with community demos, but lacks polished guides for beginners.

--- a/missing_entries.json
+++ b/missing_entries.json
@@ -51,7 +51,8 @@
     "Name": "AgentVerse",
     "Website": "https://github.com/OpenBMB/AgentVerse",
     "Description": "An open-source research platform for multi-agent collaboration and simulations. It provides an environment to configure multiple LLM-based agents with different roles that can interact with each other to solve tasks or model complex scenarios.",
-    "Reason for inclusion": "AgentVerse expands the scope into multi-agent systems research, demonstrating how multiple AI agents can be orchestrated together—an area not covered by the existing entries but relevant to advanced agent applications."
+    "Reason for inclusion": "AgentVerse expands the scope into multi-agent systems research, demonstrating how multiple AI agents can be orchestrated together—an area not covered by the existing entries but relevant to advanced agent applications.",
+    "added": true
   },
   {
     "Name": "CAMEL",


### PR DESCRIPTION
## Summary
- add research profile and metadata for AgentVerse multi-agent framework
- document persona ratings for AgentVerse and mark it as added in `missing_entries.json`

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f1aabc0c88321ba1d2b33196eff6b