### PR TITLE
Add ChatDev agent research

### DIFF
--- a/agents/ChatDev/agent_ChatDev.json
+++ b/agents/ChatDev/agent_ChatDev.json
@@ -1,0 +1,23 @@
+{
+  "name": "ChatDev",
+  "website": "https://github.com/OpenBMB/ChatDev",
+  "developer": "OpenBMB",
+  "key_features": [
+    "Virtual software company with multi-agent roles",
+    "Visualizer for observing real-time or replayed agent logs",
+    "Supports Git integration, Docker execution, and incremental development",
+    "Human-Agent Interaction mode for manual participation",
+    "MacNet framework for scalable DAG-style collaboration"
+  ],
+  "supported_models": [
+    "GPT-3.5 Turbo",
+    "GPT-4",
+    "GPT-4-32K"
+  ],
+  "pricing_model": "Open-source (Apache-2.0), free",
+  "benchmarks": {
+    "swe_bench_score": null,
+    "task_success_rate": null,
+    "resource_usage": ""
+  }
+}

--- a/agents/ChatDev/persona_ratings_chatdev.json
+++ b/agents/ChatDev/persona_ratings_chatdev.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 4,
+    "reasoning": "Coordinated agents automatically design, code, test and document software projects"
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 2,
+    "reasoning": "Requires command-line setup and API key configuration"
+  },
+  "code_quality_testing": {
+    "rating": 4,
+    "reasoning": "Includes dedicated Tester and Reviewer agents for validation"
+  },
+  "codebase_comprehension": {
+    "rating": 3,
+    "reasoning": "Agents follow structured roles but have limited large-scale repository understanding"
+  },
+  "creative_multimodal_exploration": {
+    "rating": 2,
+    "reasoning": "Focuses on software generation with minor support for visual design via Art Designer"
+  },
+  "data_experimental_flexibility": {
+    "rating": 2,
+    "reasoning": "Not primarily aimed at data science workflows"
+  },
+  "visual_no_code_development": {
+    "rating": 1,
+    "reasoning": "Operated through code and configuration files without drag-and-drop interfaces"
+  },
+  "workflow_agent_orchestration": {
+    "rating": 4,
+    "reasoning": "Multi-agent framework with MacNet enables complex DAG-based orchestration"
+  }
+}

--- a/agents/ChatDev/profile.md
+++ b/agents/ChatDev/profile.md
@@ -1,0 +1,35 @@
+# ChatDev
+
+## Overview
+
+ChatDev is a virtual software company composed of multiple intelligent agents with specialized roles such as CEO, CTO, Programmer, Reviewer, Tester, and Art Designer. These agents collaborate through LLM-driven conversations to design, code, test, and document software projects in a fully automated pipeline.
+
+## Key Information
+
+- **Developer:** OpenBMB
+- **Website:** [https://github.com/OpenBMB/ChatDev](https://github.com/OpenBMB/ChatDev)
+- **Pricing:** Open-source (Apache-2.0), free to use
+
+## Key Features
+
+- Multi-agent organizational structure with role-specific agents coordinating software development tasks
+- Visualizer for real-time and replayed logs of agent interactions
+- Configurable pipeline with support for Git integration, Docker execution, and incremental development
+- Human-Agent Interaction mode allowing a person to join the workflow (e.g., as Reviewer)
+- MacNet framework enabling scalable DAG-style multi-agent collaboration beyond software development
+
+## Supported Models
+
+- GPT-3.5 Turbo
+- GPT-4
+- GPT-4-32K
+
+## Benchmarks
+
+- No public benchmark results reported
+
+## Qualitative Assessment
+
+- **Ease of Use:** Moderate; command-line setup with optional visualizer
+- **Documentation Quality:** Comprehensive README and wiki provide detailed setup guides
+- **Onboarding Experience:** Requires manual configuration of API keys and models

--- a/missing_entries.json
+++ b/missing_entries.json
@@ -63,7 +63,8 @@
     "Name": "ChatDev",
     "Website": "https://github.com/OpenBMB/ChatDev",
     "Description": "A multi-agent system that simulates a software development team with different AI agents (e.g., Manager, Developer, Tester) collaborating to design, code, test, and document a software project. It provides a visual interface to observe agent interactions.",
-    "Reason for inclusion": "ChatDev is a cutting-edge example of domain-specific AI agents working together, illustrating the power of specialized agents and teamwork in automation—which complements the general-purpose agents in the existing list."
+    "Reason for inclusion": "ChatDev is a cutting-edge example of domain-specific AI agents working together, illustrating the power of specialized agents and teamwork in automation—which complements the general-purpose agents in the existing list.",
+    "status": "added"
   },
   {
     "Name": "Pydantic AI",


### PR DESCRIPTION
## Summary
- add research profile and metadata for ChatDev multi-agent software development framework
- record persona ratings for ChatDev
- mark ChatDev as added in missing_entries.json

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f1acadd808321a05f96453f667e4b