### PR TITLE
Add Pydantic AI agent profile

### DIFF
--- a/agents/Pydantic_AI/agent_Pydantic_AI.json
+++ b/agents/Pydantic_AI/agent_Pydantic_AI.json
@@ -1,0 +1,28 @@
+{
+  "name": "Pydantic AI",
+  "website": "https://ai.pydantic.dev/",
+  "developer": "Pydantic",
+  "key_features": [
+    "Model-agnostic support for providers like OpenAI, Anthropic, Gemini, Deepseek, Ollama, Groq, Cohere and Mistral.",
+    "Built-in Pydantic validation for type-safe, structured responses.",
+    "Seamless integration with Pydantic Logfire for real-time monitoring and debugging.",
+    "Optional dependency injection system for delivering data and services to agents.",
+    "Supports streamed responses and graph-based workflow composition."
+  ],
+  "supported_models": [
+    "OpenAI",
+    "Anthropic",
+    "Gemini",
+    "Deepseek",
+    "Ollama",
+    "Groq",
+    "Cohere",
+    "Mistral"
+  ],
+  "pricing_model": "Open Source (MIT)",
+  "benchmarks": {
+    "swe_bench_score": null,
+    "task_success_rate": null,
+    "resource_usage": ""
+  }
+}

--- a/agents/Pydantic_AI/persona_ratings_pydantic_ai.json
+++ b/agents/Pydantic_AI/persona_ratings_pydantic_ai.json
@@ -1,0 +1,34 @@
+{
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Documentation includes tutorials and examples, but assumes familiarity with Python and typed models."
+  },
+  "visual_no_code_development": {
+    "rating": 1,
+    "reasoning": "The framework is code-centric with no visual or no-code builder."
+  },
+  "automation_productivity": {
+    "rating": 4,
+    "reasoning": "Type enforcement and dependency injection streamline building reliable agents."
+  },
+  "data_experimental_flexibility": {
+    "rating": 4,
+    "reasoning": "Model-agnostic design and structured validation allow experimentation with multiple providers and data schemas."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 3,
+    "reasoning": "Graph support enables custom workflows, but orchestration features are still evolving compared to dedicated tools."
+  },
+  "codebase_comprehension": {
+    "rating": 1,
+    "reasoning": "Pydantic AI targets agent development rather than analyzing existing codebases."
+  },
+  "code_quality_testing": {
+    "rating": 3,
+    "reasoning": "Integration with Pydantic Logfire aids debugging and monitoring, though it lacks built-in testing suites."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "Supports various LLM providers but offers limited out-of-the-box tools for multimodal experimentation."
+  }
+}

--- a/agents/Pydantic_AI/profile.md
+++ b/agents/Pydantic_AI/profile.md
@@ -1,0 +1,42 @@
+# Pydantic AI
+
+## Overview
+
+Pydantic AI is a Python agent framework that brings Pydantic's type validation to generative AI applications. Built by the team behind Pydantic, it aims to provide a FastAPI-like developer experience for building reliable, production-grade agents.
+
+## Key Information
+
+- **Developer:** Pydantic
+- **Website:** [https://ai.pydantic.dev/](https://ai.pydantic.dev/)
+- **Pricing:** Open Source (MIT)
+
+## Key Features
+
+- Model-agnostic support for OpenAI, Anthropic, Gemini, Deepseek, Ollama, Groq, Cohere, and Mistral.
+- Built-in Pydantic validation for type-safe, structured responses.
+- Integration with Pydantic Logfire for real-time monitoring and debugging.
+- Optional dependency injection system for supplying data and services to agents.
+- Streamed responses and graph-based workflow composition.
+
+## Supported Models
+
+- OpenAI
+- Anthropic
+- Gemini
+- Deepseek
+- Ollama
+- Groq
+- Cohere
+- Mistral
+
+## Benchmarks
+
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+
+- **Ease of Use:** Moderate for beginners, high for Python developers due to clear API and type hints.
+- **Documentation Quality:** High, with comprehensive examples and reference materials.
+- **Onboarding Experience:** Straightforward for those familiar with Python and Pydantic.

--- a/missing_entries.json
+++ b/missing_entries.json
@@ -69,7 +69,8 @@
     "Name": "Pydantic AI",
     "Website": "https://ai.pydantic.dev/",
     "Description": "A Python framework for building AI agents with strong type validation and structured outputs. Developed by the team behind the Pydantic library, it leverages Pydantic for schema enforcement, making agent outputs more reliable and development more manageable.",
-    "Reason for inclusion": "Pydantic AI targets the need for robust, production-grade agent development, introducing typed schemas and validation into LLM workflows—an important innovation in agent design not represented in the current list."
+    "Reason for inclusion": "Pydantic AI targets the need for robust, production-grade agent development, introducing typed schemas and validation into LLM workflows—an important innovation in agent design not represented in the current list.",
+    "Added": true
   },
   {
     "Name": "Bee Agent Framework",


### PR DESCRIPTION
## Summary
- add Pydantic AI agent profile, metadata, and persona ratings
- mark Pydantic AI entry in missing_entries.json as added

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f1addef208321865f2473d403c417