### PR TITLE
Add IBM watsonx Orchestrate agent research

### DIFF
--- a/agents/IBM_watsonx_Orchestrate/agent_IBM_watsonx_Orchestrate.json
+++ b/agents/IBM_watsonx_Orchestrate/agent_IBM_watsonx_Orchestrate.json
@@ -1,0 +1,24 @@
+{
+  "name": "IBM watsonx Orchestrate",
+  "website": "https://www.ibm.com/products/watsonx-orchestrate",
+  "developer": "IBM",
+  "key_features": [
+    "Digital workers for automating business tasks",
+    "No-code workflow builder with prebuilt skills",
+    "Connectors to enterprise apps such as Slack, Workday, and SAP",
+    "Python-based Agent Development Kit (ADK) and CLI",
+    "Auditable and secure integrations"
+  ],
+  "supported_models": [
+    "IBM Granite and other foundation models available via watsonx.ai"
+  ],
+  "pricing_model": "Commercial subscription with free Developer Edition",
+  "description": "Enterprise platform for building AI-powered digital workers that automate workflows across business applications.",
+  "long_description": "watsonx Orchestrate combines a no-code interface, prebuilt skills, and IBM foundation models to let users design digital workers that execute tasks in HR, CRM, ERP, and other systems. The platform offers a developer-focused ADK and local sandbox, with governance and audit features for enterprise deployments.",
+  "benchmarks": {
+    "swe_bench_score": null,
+    "swe_bench_source": null,
+    "task_success_rate": null,
+    "resource_usage": null
+  }
+}

--- a/agents/IBM_watsonx_Orchestrate/persona_ratings_ibm_watsonx_orchestrate.json
+++ b/agents/IBM_watsonx_Orchestrate/persona_ratings_ibm_watsonx_orchestrate.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 4,
+    "reasoning": "Digital workers automate multi-step business tasks across enterprise apps, boosting productivity."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "The no-code builder and Developer Edition ease entry, but enterprise setup may require guidance."
+  },
+  "code_quality_testing": {
+    "rating": 2,
+    "reasoning": "The platform focuses on workflow automation rather than code analysis or testing."
+  },
+  "codebase_comprehension": {
+    "rating": 2,
+    "reasoning": "Designed for business processes, not for navigating or understanding software codebases."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 2,
+    "reasoning": "Uses language models for task automation but offers limited multimodal creative tools."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "Supports integration with various enterprise data sources, though experimentation is constrained by governance."
+  },
+  "visual_no_code_development": {
+    "rating": 4,
+    "reasoning": "Provides a drag-and-drop interface to build workflows and digital workers without programming."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 4,
+    "reasoning": "Designed to orchestrate tasks across multiple apps and services through digital workers."
+  }
+}

--- a/agents/IBM_watsonx_Orchestrate/profile.md
+++ b/agents/IBM_watsonx_Orchestrate/profile.md
@@ -1,0 +1,39 @@
+# IBM watsonx Orchestrate
+
+## Overview
+
+IBM watsonx Orchestrate is an AI-driven automation platform that creates digital workers to handle enterprise tasks through natural language and prebuilt skills. It provides a no-code environment for composing workflows that connect to common business applications.
+
+## Key Information
+
+- **Developer:** IBM
+- **Website:** [https://www.ibm.com/products/watsonx-orchestrate](https://www.ibm.com/products/watsonx-orchestrate)
+- **Pricing:** Enterprise licensing; free Developer Edition available for local experimentation.
+
+## Key Features
+
+- **Digital Workers:** Generative AI-driven assistants that can execute tasks across HR, ERP, CRM and other enterprise systems.
+- **No-Code Workflow Builder:** Drag-and-drop interface for chaining skills and orchestrating processes without coding.
+- **Prebuilt and Custom Skills:** Library of connectors for services like Slack, Workday, SAP, and the ability to add custom tools via the ADK.
+- **Developer Edition & ADK:** Local sandbox for building and testing agents with a Python-based CLI.
+- **Auditable Integrations:** Tracks activity with governance and security controls suited for enterprise environments.
+
+## Supported Models
+
+IBM foundation models available in watsonx.ai, including the Granite series and select open-source models.
+
+## Pricing Model
+
+Commercial subscription with usage-based licensing; contact IBM for detailed pricing. A free Developer Edition is provided for local development.
+
+## Benchmarks
+
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+
+- **Ease of Use:** 3/5 – No-code builder simplifies workflow design, but enterprise configuration can be complex.
+- **Documentation Quality:** 4/5 – Official docs and open-source examples (ADK) provide guidance.
+- **Onboarding Experience:** Developer Edition offers a straightforward local setup through the `orchestrate` CLI.

--- a/missing_entries.json
+++ b/missing_entries.json
@@ -87,7 +87,8 @@
     "Name": "IBM watsonx Orchestrate",
     "Website": "https://www.ibm.com/products/watsonx-orchestrate",
     "Description": "A commercial AI automation solution by IBM that uses generative AI to create digital workers for business tasks. It provides a no-code interface to build workflow agents that can interact with enterprise applications (HR, ERP, CRM, etc.), automating tasks with auditable, secure integrations.",
-    "Reason for inclusion": "IBM watsonx Orchestrate is a flagship example of an enterprise-focused AI agent platform. Including it extends the list to large-scale productivity agents and demonstrates the commercial side of AI-driven workflow automation."
+    "Reason for inclusion": "IBM watsonx Orchestrate is a flagship example of an enterprise-focused AI agent platform. Including it extends the list to large-scale productivity agents and demonstrates the commercial side of AI-driven workflow automation.",
+    "Status": "added"
   },
   {
     "Name": "Adept (ACT-1)",


### PR DESCRIPTION
## Summary
- add IBM watsonx Orchestrate agent profile, metadata, and persona ratings
- mark IBM watsonx Orchestrate as added in missing entries list

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f1b3c06148321be8c5b2030213acc