### PR TITLE
Add Adept ACT-1 agent research entry

### DIFF
--- a/agents/Adept_ACT-1/agent_Adept_ACT-1.json
+++ b/agents/Adept_ACT-1/agent_Adept_ACT-1.json
@@ -1,0 +1,20 @@
+{
+  "name": "Adept (ACT-1)",
+  "website": "https://www.adept.ai/",
+  "developer": "Adept AI Labs",
+  "key_features": [
+    "Translates natural language commands into actions across existing software",
+    "Observes the user interface to interact with web and desktop applications",
+    "Performs multi-step workflows such as navigating websites or filling forms",
+    "Learns from human demonstrations to improve task execution"
+  ],
+  "supported_models": [
+    "ACT-1 (Action Transformer)"
+  ],
+  "pricing_model": null,
+  "benchmarks": {
+    "swe_bench_score": null,
+    "task_success_rate": null,
+    "resource_usage": ""
+  }
+}

--- a/agents/Adept_ACT-1/persona_ratings_adept_act_1.json
+++ b/agents/Adept_ACT-1/persona_ratings_adept_act_1.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 5,
+    "reasoning": "ACT-1 is explicitly designed to execute multi-step computer tasks on behalf of the user, turning natural language instructions into actions across software. Its focus on automating routine workflows makes it highly oriented toward productivity."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 2,
+    "reasoning": "The system is not publicly available and currently requires joining a waitlist, so there is limited documentation or guided onboarding for new users."
+  },
+  "codebase_comprehension": {
+    "rating": 1,
+    "reasoning": "ACT-1 targets general computer operation rather than reading or understanding source code."
+  },
+  "code_quality_testing": {
+    "rating": 1,
+    "reasoning": "The agent does not provide tools for writing or testing code; quality assurance features are out of scope."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 2,
+    "reasoning": "While ACT-1 observes the visual interface of applications, it is primarily focused on task execution rather than creative generation across modalities."
+  },
+  "data_experimental_flexibility": {
+    "rating": 3,
+    "reasoning": "The agent can manipulate data in existing tools like spreadsheets or web forms, but it lacks native features for data experimentation or pipeline management."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "Users can automate workflows through natural language without writing code, yet customization and control remain limited."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 4,
+    "reasoning": "ACT-1 can carry out multi-step procedures across different applications, demonstrating strong cross-tool orchestration, although it currently operates as a single agent."
+  }
+}

--- a/agents/Adept_ACT-1/profile.md
+++ b/agents/Adept_ACT-1/profile.md
@@ -1,0 +1,43 @@
+# Adept (ACT-1)
+
+## Overview
+
+Adept AI Labs is developing a general-purpose AI assistant called ACT-1 (Action Transformer). The model can operate existing software on behalf of the user, translating natural-language instructions into sequences of clicks and keystrokes.
+
+## Key Information
+
+- **Developer:** Adept AI Labs
+- **Website:** [https://www.adept.ai/](https://www.adept.ai/)
+- **Pricing:** Not publicly available (private beta)
+
+## Key Features
+
+- Executes multi-step workflows across web and desktop applications
+- Observes user interfaces and interacts via cursor and keyboard
+- Learns from human demonstrations to expand its skill set
+- Aims to generalize across applications without per-app integrations
+
+## Supported Models
+
+- ACT-1 (Action Transformer)
+
+## Benchmarks
+
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+
+- **Ease of Use:** Medium (limited access)
+- **Documentation Quality:** Limited
+- **Onboarding Experience:** Waitlist only
+
+## Pricing
+
+Adept has not released public pricing for ACT-1. Access is currently limited to research partners and private testing.
+
+## Getting Started
+
+Prospective users can join the waiting list on Adept's website to receive updates about future releases.
+

--- a/missing_entries.json
+++ b/missing_entries.json
@@ -93,7 +93,8 @@
     "Name": "Adept (ACT-1)",
     "Website": "https://www.adept.ai/",
     "Description": "Adept is a startup building a general-purpose AI assistant called ACT-1 that can perform actions across existing software via natural language commands. ACT-1 (\"Action Transformer\") observes user interfaces and takes actions like clicking or typing to execute multi-step tasks on the user's behalf.",
-    "Reason for inclusion": "Adept’s ACT-1 is a high-profile example of a general AI agent aimed at automating any computer task. Its approach to directly operating software makes it relevant to the discussion of productivity agents and not represented by any entry in the current list."
+    "Reason for inclusion": "Adept’s ACT-1 is a high-profile example of a general AI agent aimed at automating any computer task. Its approach to directly operating software makes it relevant to the discussion of productivity agents and not represented by any entry in the current list.",
+    "Status": "added"
   },
   {
     "Name": "Inflection Pi",


### PR DESCRIPTION
## Summary
- add Adept (ACT-1) agent profile and metadata
- record persona ratings for Adept ACT-1
- mark Adept (ACT-1) as added in missing_entries.json

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f1b5118348321aaea425cf6549945