### PR TITLE
Add SAP Joule agent research

### DIFF
--- a/agents/SAP_Joule/agent_SAP_Joule.json
+++ b/agents/SAP_Joule/agent_SAP_Joule.json
@@ -1,0 +1,23 @@
+{
+  "name": "SAP Joule",
+  "website": "https://www.sap.com/products/artificial-intelligence/joule.html",
+  "developer": "SAP",
+  "key_features": [
+    "AI copilot for SAP applications",
+    "Context-aware insights from SAP data",
+    "Natural language interface",
+    "Cross-application integration across SAP cloud solutions",
+    "Built on SAP Business Technology Platform",
+    "Security and compliance controls"
+  ],
+  "supported_models": [
+    "Large language models via SAP's AI Core",
+    "Third-party models (e.g., OpenAI) through SAP's generative AI hub"
+  ],
+  "pricing_model": "Included with select SAP cloud subscriptions (details not public)",
+  "benchmarks": {
+    "swe_bench_score": null,
+    "task_success_rate": null,
+    "resource_usage": ""
+  }
+}

--- a/agents/SAP_Joule/persona_ratings_sap_joule.json
+++ b/agents/SAP_Joule/persona_ratings_sap_joule.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 4,
+    "reasoning": "Joule automates routine SAP tasks and surfaces contextual insights to accelerate business workflows across SAP applications."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 3,
+    "reasoning": "Existing SAP users can access Joule within familiar interfaces, but setup and availability depend on enterprise configurations."
+  },
+  "code_quality_testing": {
+    "rating": 1,
+    "reasoning": "Joule focuses on business process assistance rather than software development or code testing."
+  },
+  "codebase_comprehension": {
+    "rating": 1,
+    "reasoning": "The assistant does not analyze programming code or software architectures."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 1,
+    "reasoning": "Joule primarily handles text-based enterprise data without notable multimodal creation capabilities."
+  },
+  "data_experimental_flexibility": {
+    "rating": 2,
+    "reasoning": "It can draw on SAP business data for analysis but offers limited tooling for open-ended experimentation."
+  },
+  "visual_no_code_development": {
+    "rating": 2,
+    "reasoning": "Natural language interaction reduces the need for custom code, yet it does not provide a visual builder for creating applications."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 4,
+    "reasoning": "Joule connects across SAP's cloud suite to coordinate tasks and processes, supporting cross-application orchestration."
+  }
+}

--- a/agents/SAP_Joule/profile.md
+++ b/agents/SAP_Joule/profile.md
@@ -1,0 +1,45 @@
+# SAP Joule
+
+## Overview
+
+SAP Joule is a generative AI copilot embedded across SAP's enterprise cloud applications. It uses large language models and domain-specific business data to provide contextual insights, automate tasks, and streamline workflows inside SAP solutions.
+
+## Key Information
+
+- **Developer:** SAP
+- **Website:** [https://www.sap.com/products/artificial-intelligence/joule.html](https://www.sap.com/products/artificial-intelligence/joule.html)
+- **Pricing:** Included with select SAP cloud offerings (details not publicly listed)
+
+## Key Features
+
+- **AI copilot for SAP applications:** Conversational assistant that helps users interact with SAP systems.
+- **Context-aware insights:** Surfaces relevant information from SAP data to guide decisions and actions.
+- **Natural language interface:** Users can ask questions or issue commands in plain language.
+- **Cross-application integration:** Works across solutions like SAP S/4HANA, SAP SuccessFactors, SAP Ariba, and more.
+- **Built on SAP Business Technology Platform:** Utilizes SAP's generative AI hub and governance tools.
+- **Security and compliance controls:** Designed for enterprise-grade privacy, data protection, and governance.
+
+## Supported Models
+
+- Large language models available through SAP's AI Core
+- Third-party models (e.g., OpenAI) via SAP's generative AI hub
+
+## Benchmarks
+
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+
+- **Ease of Use:** Moderate
+- **Documentation Quality:** Moderate
+- **Onboarding Experience:** Streamlined for existing SAP customers
+
+## Pricing
+
+Pricing information for SAP Joule is not publicly available. Prospective users should contact SAP or consult their existing SAP subscriptions for details.
+
+## Getting Started
+
+SAP Joule is available within select SAP cloud products. Existing SAP customers can enable Joule through their SAP administrator or support channel.


### PR DESCRIPTION
## Summary
- add SAP Joule agent profile detailing overview, features, models, and pricing
- include structured agent JSON and persona ratings

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689f1ba4b8f88321990cc65d688f0e1e