### PR TITLE
feat: simplify pricing categories in agent table

### DIFF
--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -245,7 +245,7 @@
       "Grok 4",
       "Kimi K2"
     ],
-    "pricing_model": "$10 per month, with the first month discounted to $3.",
+    "pricing_model": "$10 per month.",
     "benchmarks": {
       "swe_bench_score": "Top score on SWE-bench Verified as of July 2025",
       "swe_bench_source": "https://www.datacamp.com/tutorial/trae-ai",
@@ -784,7 +784,7 @@
       "MiniMax Hailuo 02 (Video)",
       "MiniMax Speech 02 (Audio)"
     ],
-    "pricing_model": "MiniMax M1 (text): $0.40 per 1M input tokens; Speech-02-HD (audio): $100 per 1M characters; Hailuo 02 (video): from $0.28 per video",
+    "pricing_model": "MiniMax M1 (text): $0.40 per 1M input tokens; Speech-02-HD (audio): $100 per 1M characters; Hailuo 02 (video): $0.28 per video.",
     "benchmarks": {
       "swe_bench_score": null,
       "task_success_rate": null,
@@ -1280,29 +1280,6 @@
       "swe_bench_score": null,
       "task_success_rate": null,
       "resource_usage": ""
-    }
-  },
-  {
-    "name": "Minimax agent",
-    "website": "https://www.minimaxi.com/",
-    "developer": "MiniMax",
-    "key_features": [
-      "Text Model (MiniMax M1) with 1M token input",
-      "Video Model (MiniMax Hailuo 02) with 1080p output",
-      "Audio Model (MiniMax Speech 02) for speech generation",
-      "MCP Server for developers (Video, Image, Speech generation, Voice Cloning)",
-      "AI-native applications: MiniMax Chat, MiniMax Agent, Hailuo Video, MiniMax Audio, Talkie"
-    ],
-    "supported_models": [
-      "MiniMax M1 (Text)",
-      "MiniMax Hailuo 02 (Video)",
-      "MiniMax Speech 02 (Audio)"
-    ],
-    "pricing_model": "MiniMax-M1 (text): Starts at $0.4/M tokens input, Speech-02-HD (audio): $100 per 1M characters, MiniMax Hailuo 02 (video): Starting from $0.28 per video",
-    "benchmarks": {
-      "swe_bench_score": null,
-      "task_success_rate": null,
-      "resource_usage": "No public benchmarks found"
     }
   },
   {

--- a/website/src/components/AgentTable.jsx
+++ b/website/src/components/AgentTable.jsx
@@ -142,6 +142,92 @@ const AgentTable = forwardRef(function AgentTable(
     return filled + empty;
   };
 
+  const categorizePricing = (pricing) => {
+    if (!pricing) {
+      return "undisclosed (or part of a larger subscription or license)";
+    }
+
+    const lower = pricing.toLowerCase();
+    const amounts = pricing.match(/\$[0-9]+(?:\.[0-9]+)?/g) || [];
+    const parts = [];
+
+    const isOpenSource =
+      lower.includes("open-source") || lower.includes("open source");
+    const requiresKeyOrSelfHost =
+      lower.includes("api key") ||
+      lower.includes("api keys") ||
+      lower.includes("byok") ||
+      lower.includes("bring your own") ||
+      lower.includes("self-host") ||
+      lower.includes("self host") ||
+      lower.includes("self-hosted") ||
+      lower.includes("self hosted") ||
+      lower.includes("local deployment") ||
+      lower.includes("deploy locally");
+    const mentionsHostedFree =
+      lower.includes("hosted for free") ||
+      (lower.includes("saas") && lower.includes("free"));
+
+    const hasFree = lower.includes("free") && !lower.includes("trial");
+    if (hasFree) {
+      if (
+        lower.includes("free tier") ||
+        lower.includes("limited free") ||
+        lower.includes("free plan") ||
+        lower.includes("limit") ||
+        lower.includes("tier") ||
+        amounts.length
+      ) {
+        parts.push("Limited free tier");
+      } else if (!isOpenSource || mentionsHostedFree) {
+        parts.push("Free (including usage!)");
+      }
+    }
+
+    const variableIndicators = [
+      "usage",
+      "pay-as-you-go",
+      "per token",
+      "per request",
+      "per call",
+      "per character",
+      "per char",
+      "per video",
+      "per image",
+      "per second",
+      "per minute",
+      "per 1m",
+      "per million",
+    ];
+    if (
+      variableIndicators.some((v) => lower.includes(v)) ||
+      requiresKeyOrSelfHost ||
+      (isOpenSource && !mentionsHostedFree)
+    ) {
+      parts.push("Variable by (API-) usage");
+    } else if (lower.includes("credit")) {
+      parts.push(
+        amounts.length
+          ? `Flat rate with credits (${amounts.join(", ")})`
+          : "Flat rate with credits"
+      );
+    } else if (lower.includes("limit") || lower.includes("tier")) {
+      parts.push(
+        amounts.length
+          ? `Flat rate with usage limits (${amounts.join(", ")})`
+          : "Flat rate with usage limits"
+      );
+    } else if (amounts.length) {
+      parts.push(`Flat rate (${amounts.join(", ")})`);
+    }
+
+    if (parts.length === 0) {
+      parts.push("undisclosed (or part of a larger subscription or license)");
+    }
+
+    return parts.join(", ");
+  };
+
   const toggleCriterion = (id) => {
     setSelectedCriteria((prev) =>
       prev.includes(id) ? prev.filter((c) => c !== id) : [...prev, id]
@@ -163,7 +249,7 @@ const AgentTable = forwardRef(function AgentTable(
         agent.name,
         agent.website,
         agent.developer,
-        agent.pricing_model,
+        categorizePricing(agent.pricing_model),
         ...criteria.map((c) => ratings[key]?.[c.id]?.rating ?? ""),
       ];
     });
@@ -269,7 +355,9 @@ const AgentTable = forwardRef(function AgentTable(
                 </a>
               </td>
               <td className="px-4 py-2">{agent.developer}</td>
-              <td className="px-4 py-2">{agent.pricing_model}</td>
+              <td className="px-4 py-2">
+                {categorizePricing(agent.pricing_model)}
+              </td>
               {criteria.map((c) => (
                 <td key={c.id} className="px-2 py-2 text-center">
                   {renderStars(


### PR DESCRIPTION
## Summary
- refine pricing categorization to handle limited free tiers and detect per-use billing across more patterns
- update agent data: Trae now $10/month and Minimax pricing clarified, duplicate removed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f29f1d8cc83218046afdd65cc2d77