### PR TITLE
Re-enable AgentTable filters on main view and disable on persona pages

### DIFF
--- a/website/src/components/AgentTable.jsx
+++ b/website/src/components/AgentTable.jsx
@@ -12,6 +12,7 @@ const AgentTable = forwardRef(function AgentTable(
     searchTerm = "",
     initialCriteria = [],
     limit,
+    allowCriterionSelection = true,
   },
   ref
 ) {
@@ -229,6 +230,7 @@ const AgentTable = forwardRef(function AgentTable(
   };
 
   const toggleCriterion = (id) => {
+    if (!allowCriterionSelection) return;
     setSelectedCriteria((prev) =>
       prev.includes(id) ? prev.filter((c) => c !== id) : [...prev, id]
     );
@@ -309,7 +311,22 @@ const AgentTable = forwardRef(function AgentTable(
               <th key={c.id} className="px-2 py-2 font-archia">
                 <div className="flex items-center justify-center gap-1">
                   <span>{c.name}</span>
-                  <button type="button" onClick={() => toggleCriterion(c.id)}>
+                  {allowCriterionSelection ? (
+                    <button type="button" onClick={() => toggleCriterion(c.id)}>
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        className={`w-3 h-3 ${
+                          selectedCriteria.includes(c.id)
+                            ? "text-white"
+                            : "text-white/50"
+                        }`}
+                      >
+                        <path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-.293.707L11 12.414V16a1 1 0 01-1.447.894L8 15v-2.586L3.293 6.707A1 1 0 013 6V4z" />
+                      </svg>
+                    </button>
+                  ) : (
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
                       viewBox="0 0 20 20"
@@ -322,7 +339,7 @@ const AgentTable = forwardRef(function AgentTable(
                     >
                       <path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-.293.707L11 12.414V16a1 1 0 01-1.447.894L8 15v-2.586L3.293 6.707A1 1 0 013 6V4z" />
                     </svg>
-                  </button>
+                  )}
                 </div>
               </th>
             ))}

--- a/website/src/pages/PersonaDetail.jsx
+++ b/website/src/pages/PersonaDetail.jsx
@@ -86,6 +86,7 @@ function PersonaDetail({ onAgentClick }) {
         onAgentClick={onAgentClick}
         initialCriteria={persona.criteriaIds}
         limit={5}
+        allowCriterionSelection={false}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- allow filter icons to be clickable on the main AgentTable
- prevent filter toggling in persona detail views

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f3fd117e48321b62b313020c361d3