### PR TITLE
fix: update Roo Code website link

### DIFF
--- a/agents/Roo_Code/agent_Roo_Code.json
+++ b/agents/Roo_Code/agent_Roo_Code.json
@@ -1,6 +1,6 @@
 {
   "name": "Roo Code",
-  "website": "https://roo.ai/",
+  "website": "https://github.com/RooCodeInc/Roo-Code",
   "developer": "ROO.AI",
   "key_features": [
     "NOTE: Roo Code is not a publicly available product. The information is based on the ROO.AI platform.",

--- a/agents/Roo_Code/profile.md
+++ b/agents/Roo_Code/profile.md
@@ -1,6 +1,6 @@
 # Roo Code
 
-**Note:** "Roo Code" does not appear to be a publicly available product. The information below is based on the [ROO.AI](https://roo.ai/) platform, which is a connected worker platform for manufacturing and other industries.
+**Note:** "Roo Code" does not appear to be a publicly available product. The information below is based on the [Roo Code](https://github.com/RooCodeInc/Roo-Code) project, which is a connected worker platform for manufacturing and other industries.
 
 ## Overview
 
@@ -11,7 +11,7 @@ While ROO.AI uses "AI Agents", it is not a coding assistant or a developer tool 
 ## Key Information
 
 - **Developer:** ROO.AI
-- **Website:** [https://roo.ai/](https://roo.ai/)
+- **Website:** [https://github.com/RooCodeInc/Roo-Code](https://github.com/RooCodeInc/Roo-Code)
 - **Pricing:** Not specified for a 'Roo Code' product. ROO.AI has its own pricing model for its platform.
 
 ## Key Features

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -726,7 +726,7 @@
   },
   {
     "name": "Roo Code",
-    "website": "https://roo.ai/",
+    "website": "https://github.com/RooCodeInc/Roo-Code",
     "developer": "ROO.AI",
     "key_features": [
       "NOTE: Roo Code is not a publicly available product. The information is based on the ROO.AI platform.",


### PR DESCRIPTION
## Summary
- point Roo Code agent data and website entry to correct GitHub repository

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f43a865dc83218d34ff6a23022195