### PR TITLE
Enable AgentTable filters on main view only

### DIFF
--- a/website/src/components/AgentTable.jsx
+++ b/website/src/components/AgentTable.jsx
@@ -12,7 +12,7 @@ const AgentTable = forwardRef(function AgentTable(
     searchTerm = "",
     initialCriteria = [],
     limit,
-    allowCriterionSelection = true,
+    allowCriterionSelection = false,
   },
   ref
 ) {

--- a/website/src/pages/Home.jsx
+++ b/website/src/pages/Home.jsx
@@ -75,6 +75,7 @@ function Home({ onAgentClick, onOpenPersonas }) {
         ref={tableRef}
         onAgentClick={onAgentClick}
         searchTerm={searchTerm}
+        allowCriterionSelection
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Enable filter selection in Home's AgentTable
- Disable filter selection by default so persona views remain static

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f4602c61883219f6c6a0fc15fc48f