### PR TITLE
Enable AgentTable filters on main view only

### DIFF
--- a/website/src/components/AgentTable.jsx
+++ b/website/src/components/AgentTable.jsx
@@ -10,9 +10,9 @@ const AgentTable = forwardRef(function AgentTable(
     onAgentClick,
     filterNames,
     searchTerm = "",
-    initialCriteria = [],
+    initialCriteria,
     limit,
-    allowCriterionSelection = true,
+    allowCriterionSelection = false,
   },
   ref
 ) {
@@ -21,10 +21,10 @@ const AgentTable = forwardRef(function AgentTable(
   const [sortConfig, setSortConfig] = useState({ key: "name", direction: "asc" });
   const [ratings, setRatings] = useState({});
   const [criteria, setCriteria] = useState([]);
-  const [selectedCriteria, setSelectedCriteria] = useState(initialCriteria);
+  const [selectedCriteria, setSelectedCriteria] = useState(initialCriteria ?? []);
 
   useEffect(() => {
-    setSelectedCriteria(initialCriteria);
+    setSelectedCriteria(initialCriteria ?? []);
   }, [initialCriteria]);
 
   useEffect(() => {

--- a/website/src/pages/Home.jsx
+++ b/website/src/pages/Home.jsx
@@ -75,6 +75,7 @@ function Home({ onAgentClick, onOpenPersonas }) {
         ref={tableRef}
         onAgentClick={onAgentClick}
         searchTerm={searchTerm}
+        allowCriterionSelection
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Allow main AgentTable filters to remain selectable by preventing `initialCriteria` from resetting on every render

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f4602c61883219f6c6a0fc15fc48f