### PR TITLE
Clarify pricing models

### DIFF
--- a/agents/Adept_ACT-1/agent_Adept_ACT-1.json
+++ b/agents/Adept_ACT-1/agent_Adept_ACT-1.json
@@ -11,7 +11,7 @@
   "supported_models": [
     "ACT-1 (Action Transformer)"
   ],
-  "pricing_model": null,
+  "pricing_model": "Pricing not publicly disclosed (research project)",
   "benchmarks": {
     "swe_bench_score": null,
     "task_success_rate": null,

--- a/agents/Kilo/agent_Kilo.json
+++ b/agents/Kilo/agent_Kilo.json
@@ -12,7 +12,7 @@
   "supported_models": [
     "GPT-4 and open-source large language models orchestrated by Kilo"
   ],
-  "pricing_model": "Closed beta (join waitlist)",
+  "pricing_model": "Open-source; users provide API keys and pay for model usage",
   "benchmarks": {
     "swe_bench_score": null,
     "task_success_rate": null,

--- a/agents/Roo_Code/agent_Roo_Code.json
+++ b/agents/Roo_Code/agent_Roo_Code.json
@@ -12,7 +12,7 @@
   "supported_models": [
     "Any OpenAI-compatible or custom API/model (including local models via MCP)"
   ],
-  "pricing_model": "Free (open source)",
+  "pricing_model": "Open-source; users provide API keys and pay for model usage",
   "benchmarks": {
     "swe_bench_score": null,
     "task_success_rate": null,

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -484,7 +484,7 @@
     "supported_models": [
       "GPT-4 and open-source large language models orchestrated by Kilo"
     ],
-    "pricing_model": "Closed beta (join waitlist)",
+    "pricing_model": "Open-source; users provide API keys and pay for model usage",
     "benchmarks": {
       "swe_bench_score": null,
       "task_success_rate": null,
@@ -738,7 +738,7 @@
     "supported_models": [
       "Any OpenAI-compatible or custom API/model (including local models via MCP)"
     ],
-    "pricing_model": "Free (open source)",
+    "pricing_model": "Open-source; users provide API keys and pay for model usage",
     "benchmarks": {
       "swe_bench_score": null,
       "task_success_rate": null,
@@ -1366,7 +1366,7 @@
     "supported_models": [
       "ACT-1 (Action Transformer)"
     ],
-    "pricing_model": null,
+    "pricing_model": "Pricing not publicly disclosed (research project)",
     "benchmarks": {
       "swe_bench_score": null,
       "task_success_rate": null,


### PR DESCRIPTION
## Summary
- Clarify that Kilo is open-source and requires users to bring their own API usage
- Note Roo Code's open-source model and usage-based costs
- Mark Adept ACT-1 pricing as undisclosed research project

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f5696ea1c8321a65f2d2c12c6f360