### PR TITLE
Fix persona ratings for dotted agent names

### DIFF
--- a/website/src/components/AgentDetailModal.jsx
+++ b/website/src/components/AgentDetailModal.jsx
@@ -39,13 +39,13 @@ function AgentDetailModal({ agent, onClose }) {
     return filled + empty;
   };
 
-  const getAgentKey = (name) => {
-    if (!name) return "";
-    const lower = name.toLowerCase();
-    const base = lower.split(".")[0];
-    const withSpaces = base.replace(/\s+/g, "_");
-    return withSpaces.replace(/[^a-z0-9_]/g, "_");
-  };
+    const getAgentKey = (name) => {
+      if (!name) return "";
+      return name
+        .toLowerCase()
+        .replace(/\s+/g, "_")
+        .replace(/[^a-z0-9._]/g, "_");
+    };
 
   const agentKey = getAgentKey(agent.name);
   const agentRatings = ratings[agentKey] || {};


### PR DESCRIPTION
## Summary
- derive agent keys without stripping dots so persona ratings load for chat.z.ai and similar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f95d919208321a02051a3041664d7