### PR TITLE
Add ChatDev description to agent data

### DIFF
--- a/agents/ChatDev/agent_ChatDev.json
+++ b/agents/ChatDev/agent_ChatDev.json
@@ -19,5 +19,7 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  }
+  },
+  "description": "ChatDev is an open-source virtual software company where role-based agents collaborate to design, code, test, and document software.",
+  "long_description": "Leveraging a MacNet-based pipeline, ChatDev coordinates specialized agents such as CEO, CTO, programmer, reviewer, tester, and designer. It integrates with Git and Docker, provides real-time log visualization, and supports human participation for customizable end-to-end software development."
 }

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -192,9 +192,9 @@
     ],
     "pricing_model": "Cloud-based platform with Free, Pro ($20/month), Scale ($750/month), and Enterprise tiers.",
     "benchmarks": {
-      "terminal_bench_score": "42.5% ± 0.8",
+      "terminal_bench_score": "42.5% \u00b1 0.8",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
-      "terminal_bench_score_from_leaderboard": "42.5% ± 0.8"
+      "terminal_bench_score_from_leaderboard": "42.5% \u00b1 0.8"
     },
     "description": "Letta is a platform for building stateful AI agents that retain long-term memory and expose their capabilities through REST APIs. Built on MemGPT, it offers tools to visualize agent reasoning and integrate custom tools across multiple frameworks."
   },
@@ -217,11 +217,11 @@
     ],
     "pricing_model": "Requires an OpenAI API key or a paid OpenAI account (Plus/Pro).",
     "benchmarks": {
-      "terminal_bench_score": "20.0% ± 1.5",
+      "terminal_bench_score": "20.0% \u00b1 1.5",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.2,
       "resource_usage": "Runs locally; resource usage depends on chosen model",
-      "terminal_bench_score_from_leaderboard": "20.0% ± 1.5"
+      "terminal_bench_score_from_leaderboard": "20.0% \u00b1 1.5"
     },
     "description": "Codex CLI is an open-source coding agent from OpenAI that runs locally on your computer and interacts with your terminal."
   },
@@ -346,7 +346,7 @@
       "task_success_rate": null,
       "resource_usage": ""
     },
-    "description": "Amazon CodeWhisperer is a machine learning (ML)–powered service that helps improve developer productivity by generating code recommendations based on their comments in natural language and code in the integrated development environment (IDE). It is in the process of being integrated into Amazon Q Developer."
+    "description": "Amazon CodeWhisperer is a machine learning (ML)\u2013powered service that helps improve developer productivity by generating code recommendations based on their comments in natural language and code in the integrated development environment (IDE). It is in the process of being integrated into Amazon Q Developer."
   },
   {
     "name": "Tabnine",
@@ -668,11 +668,11 @@
     "benchmarks": {
       "swe_bench_score": 49,
       "swe_bench_source": "https://www.anthropic.com/research/swe-bench-sonnet",
-      "terminal_bench_score": "43.2% ± 1.3",
+      "terminal_bench_score": "43.2% \u00b1 1.3",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.432,
       "resource_usage": "Not publicly documented",
-      "terminal_bench_score_from_leaderboard": "43.2% ± 1.3"
+      "terminal_bench_score_from_leaderboard": "43.2% \u00b1 1.3"
     },
     "description": "Terminal-based coding assistant that understands your codebase and handles git workflows through natural language commands."
   },
@@ -692,11 +692,11 @@
     ],
     "pricing_model": "Open-source under the MIT License; free for self-hosting with optional paid usage-based hosting via Daytona",
     "benchmarks": {
-      "terminal_bench_score": "41.3% ± 0.7",
+      "terminal_bench_score": "41.3% \u00b1 0.7",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.413,
       "resource_usage": "Not publicly documented; depends on hosting environment and model",
-      "terminal_bench_score_from_leaderboard": "41.3% ± 0.7"
+      "terminal_bench_score_from_leaderboard": "41.3% \u00b1 0.7"
     },
     "description": "OpenHands is an open-source AI coding agent and framework from Daytona that aims to let agents perform end-to-end software development tasks."
   },
@@ -858,11 +858,11 @@
     ],
     "pricing_model": "Open-source",
     "benchmarks": {
-      "terminal_bench_score": "42.0% ± 1.3",
+      "terminal_bench_score": "42.0% \u00b1 1.3",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.42,
       "resource_usage": "Depends on local hardware and model; no public metrics",
-      "terminal_bench_score_from_leaderboard": "42.0% ± 1.3"
+      "terminal_bench_score_from_leaderboard": "42.0% \u00b1 1.3"
     },
     "description": "Goose is an open-source, on-machine AI agent from Block that automates engineering tasks autonomously."
   },
@@ -907,7 +907,7 @@
     ],
     "pricing_model": "Research project, likely free to use.",
     "benchmarks": {
-      "terminal_bench_score": "39.9% ± 1.0",
+      "terminal_bench_score": "39.9% \u00b1 1.0",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.399,
       "resource_usage": "Not publicly documented; depends on remote environment and model"
@@ -986,7 +986,7 @@
       "task_success_rate": 0.52,
       "resource_usage": "Not publicly documented; depends on local hardware and active agents",
       "swe_bench_score": "71%",
-      "terminal_bench_score_from_leaderboard": "52.0% ± 1.0"
+      "terminal_bench_score_from_leaderboard": "52.0% \u00b1 1.0"
     },
     "description": "Warp is an agentic development environment and terminal that enables fast, native interactions with multiple AI agents across the development workflow."
   },
@@ -1138,7 +1138,7 @@
     ],
     "pricing_model": "Freemium with paid plans starting at $19.99/month",
     "description": "Zapier is a web-based automation service that connects apps and automates workflows with a visual builder and optional AI features.",
-    "long_description": "Zapier lets users build \"Zaps\" that trigger actions across thousands of services. Its drag-and-drop interface, code steps, and AI Actions allow both non‑technical and technical users to automate complex multi-step processes without managing infrastructure.",
+    "long_description": "Zapier lets users build \"Zaps\" that trigger actions across thousands of services. Its drag-and-drop interface, code steps, and AI Actions allow both non\u2011technical and technical users to automate complex multi-step processes without managing infrastructure.",
     "benchmarks": {
       "swe_bench_score": null,
       "swe_bench_source": null,
@@ -1351,7 +1351,9 @@
       "swe_bench_score": null,
       "task_success_rate": null,
       "resource_usage": ""
-    }
+    },
+    "description": "ChatDev is an open-source virtual software company where role-based agents collaborate to design, code, test, and document software.",
+    "long_description": "Leveraging a MacNet-based pipeline, ChatDev coordinates specialized agents such as CEO, CTO, programmer, reviewer, tester, and designer. It integrates with Git and Docker, provides real-time log visualization, and supports human participation for customizable end-to-end software development."
   },
   {
     "name": "Adept (ACT-1)",
@@ -1414,7 +1416,7 @@
       "100+ LLMs via LiteLLM"
     ],
     "pricing_model": "Open-source MIT license; pay for underlying model and compute usage.",
-    "description": "OpenAI’s official agent SDK, formerly known as Swarm, providing minimal components to build custom LLM agents.",
+    "description": "OpenAI\u2019s official agent SDK, formerly known as Swarm, providing minimal components to build custom LLM agents.",
     "long_description": "The Agents SDK offers agents, tools, handoffs, guardrails, sessions, and tracing to compose autonomous multi-agent applications. It integrates with OpenAI Responses and Chat Completions APIs and other models through LiteLLM.",
     "benchmarks": {
       "swe_bench_score": null,
@@ -1598,7 +1600,7 @@
       "resource_usage": ""
     },
     "description": "Open-source toolkit for building production-ready multi-agent systems in Python or TypeScript.",
-    "long_description": "Bee Agent Framework provides modular components—agents, workflows, tools, memory, and more—to assemble and orchestrate complex AI applications without extensive coding."
+    "long_description": "Bee Agent Framework provides modular components\u2014agents, workflows, tools, memory, and more\u2014to assemble and orchestrate complex AI applications without extensive coding."
   },
   {
     "name": "AutoGPT",

--- a/website/public/agents.json.bak
+++ b/website/public/agents.json.bak
@@ -192,9 +192,9 @@
     ],
     "pricing_model": "Cloud-based platform with a free tier and enterprise options.",
     "benchmarks": {
-      "terminal_bench_score": "42.5% ± 0.8",
+      "terminal_bench_score": "42.5% \u00b1 0.8",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
-      "terminal_bench_score_from_leaderboard": "42.5% ± 0.8"
+      "terminal_bench_score_from_leaderboard": "42.5% \u00b1 0.8"
     },
     "description": "Letta is a platform for building stateful AI agents that retain long-term memory and expose their capabilities through REST APIs. Built on MemGPT, it offers tools to visualize agent reasoning and integrate custom tools across multiple frameworks."
   },
@@ -217,11 +217,11 @@
     ],
     "pricing_model": "Requires an OpenAI API key or a paid OpenAI account (Plus/Pro).",
     "benchmarks": {
-      "terminal_bench_score": "20.0% ± 1.5",
+      "terminal_bench_score": "20.0% \u00b1 1.5",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.2,
       "resource_usage": "Runs locally; resource usage depends on chosen model",
-      "terminal_bench_score_from_leaderboard": "20.0% ± 1.5"
+      "terminal_bench_score_from_leaderboard": "20.0% \u00b1 1.5"
     },
     "description": "Codex CLI is an open-source coding agent from OpenAI that runs locally on your computer and interacts with your terminal."
   },
@@ -346,7 +346,7 @@
       "task_success_rate": null,
       "resource_usage": ""
     },
-    "description": "Amazon CodeWhisperer is a machine learning (ML)–powered service that helps improve developer productivity by generating code recommendations based on their comments in natural language and code in the integrated development environment (IDE). It is in the process of being integrated into Amazon Q Developer."
+    "description": "Amazon CodeWhisperer is a machine learning (ML)\u2013powered service that helps improve developer productivity by generating code recommendations based on their comments in natural language and code in the integrated development environment (IDE). It is in the process of being integrated into Amazon Q Developer."
   },
   {
     "name": "Tabnine",
@@ -668,11 +668,11 @@
     "benchmarks": {
       "swe_bench_score": 49,
       "swe_bench_source": "https://www.anthropic.com/research/swe-bench-sonnet",
-      "terminal_bench_score": "43.2% ± 1.3",
+      "terminal_bench_score": "43.2% \u00b1 1.3",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.432,
       "resource_usage": "Not publicly documented",
-      "terminal_bench_score_from_leaderboard": "43.2% ± 1.3"
+      "terminal_bench_score_from_leaderboard": "43.2% \u00b1 1.3"
     },
     "description": "Terminal-based coding assistant that understands your codebase and handles git workflows through natural language commands."
   },
@@ -692,11 +692,11 @@
     ],
     "pricing_model": "Open-source under the MIT License; free for self-hosting with optional paid hosting via Daytona",
     "benchmarks": {
-      "terminal_bench_score": "41.3% ± 0.7",
+      "terminal_bench_score": "41.3% \u00b1 0.7",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.413,
       "resource_usage": "Not publicly documented; depends on hosting environment and model",
-      "terminal_bench_score_from_leaderboard": "41.3% ± 0.7"
+      "terminal_bench_score_from_leaderboard": "41.3% \u00b1 0.7"
     },
     "description": "OpenHands is an open-source AI coding agent and framework from Daytona that aims to let agents perform end-to-end software development tasks."
   },
@@ -858,11 +858,11 @@
     ],
     "pricing_model": "Open-source",
     "benchmarks": {
-      "terminal_bench_score": "42.0% ± 1.3",
+      "terminal_bench_score": "42.0% \u00b1 1.3",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.42,
       "resource_usage": "Depends on local hardware and model; no public metrics",
-      "terminal_bench_score_from_leaderboard": "42.0% ± 1.3"
+      "terminal_bench_score_from_leaderboard": "42.0% \u00b1 1.3"
     },
     "description": "Goose is an open-source, on-machine AI agent from Block that automates engineering tasks autonomously."
   },
@@ -907,7 +907,7 @@
     ],
     "pricing_model": "Research project, likely free to use.",
     "benchmarks": {
-      "terminal_bench_score": "39.9% ± 1.0",
+      "terminal_bench_score": "39.9% \u00b1 1.0",
       "terminal_bench_source": "https://www.tbench.ai/leaderboard",
       "task_success_rate": 0.399,
       "resource_usage": "Not publicly documented; depends on remote environment and model"
@@ -986,7 +986,7 @@
       "task_success_rate": 0.52,
       "resource_usage": "Not publicly documented; depends on local hardware and active agents",
       "swe_bench_score": "71%",
-      "terminal_bench_score_from_leaderboard": "52.0% ± 1.0"
+      "terminal_bench_score_from_leaderboard": "52.0% \u00b1 1.0"
     },
     "description": "Warp is an agentic development environment and terminal that enables fast, native interactions with multiple AI agents across the development workflow."
   },
@@ -1138,7 +1138,7 @@
     ],
     "pricing_model": "Freemium with paid plans starting at $19.99/month",
     "description": "Zapier is a web-based automation service that connects apps and automates workflows with a visual builder and optional AI features.",
-    "long_description": "Zapier lets users build \"Zaps\" that trigger actions across thousands of services. Its drag-and-drop interface, code steps, and AI Actions allow both non‑technical and technical users to automate complex multi-step processes without managing infrastructure.",
+    "long_description": "Zapier lets users build \"Zaps\" that trigger actions across thousands of services. Its drag-and-drop interface, code steps, and AI Actions allow both non\u2011technical and technical users to automate complex multi-step processes without managing infrastructure.",
     "benchmarks": {
       "swe_bench_score": null,
       "swe_bench_source": null,
@@ -1351,7 +1351,9 @@
       "swe_bench_score": null,
       "task_success_rate": null,
       "resource_usage": ""
-    }
+    },
+    "description": "ChatDev is an open-source virtual software company where role-based agents collaborate to design, code, test, and document software.",
+    "long_description": "Leveraging a MacNet-based pipeline, ChatDev coordinates specialized agents such as CEO, CTO, programmer, reviewer, tester, and designer. It integrates with Git and Docker, provides real-time log visualization, and supports human participation for customizable end-to-end software development."
   },
   {
     "name": "Adept (ACT-1)",
@@ -1414,7 +1416,7 @@
       "100+ LLMs via LiteLLM"
     ],
     "pricing_model": "Open-source MIT license; pay for underlying model and compute usage.",
-    "description": "OpenAI’s official agent SDK, formerly known as Swarm, providing minimal components to build custom LLM agents.",
+    "description": "OpenAI\u2019s official agent SDK, formerly known as Swarm, providing minimal components to build custom LLM agents.",
     "long_description": "The Agents SDK offers agents, tools, handoffs, guardrails, sessions, and tracing to compose autonomous multi-agent applications. It integrates with OpenAI Responses and Chat Completions APIs and other models through LiteLLM.",
     "benchmarks": {
       "swe_bench_score": null,
@@ -1598,7 +1600,7 @@
       "resource_usage": ""
     },
     "description": "Open-source toolkit for building production-ready multi-agent systems in Python or TypeScript.",
-    "long_description": "Bee Agent Framework provides modular components—agents, workflows, tools, memory, and more—to assemble and orchestrate complex AI applications without extensive coding."
+    "long_description": "Bee Agent Framework provides modular components\u2014agents, workflows, tools, memory, and more\u2014to assemble and orchestrate complex AI applications without extensive coding."
   },
   {
     "name": "AutoGPT",


### PR DESCRIPTION
## Summary
- add short and long descriptions for ChatDev
- update website agent data to show the new description

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f969b15cc8321a0a98f98b492af67