### PR TITLE
fix: update Kilo onboarding info

### DIFF
--- a/agents/Kilo/agent_Kilo.json
+++ b/agents/Kilo/agent_Kilo.json
@@ -18,6 +18,6 @@
     "task_success_rate": null,
     "resource_usage": null
   },
-  "description": "Kilo is an AI software engineering agent that connects to GitHub and implements tasks from natural-language prompts.",
-  "long_description": "Developed by Kilo Labs, the agent plans code changes, edits files, runs tests, and opens pull requests. It is currently available in a closed beta."
+  "description": "Kilo is an open-source VS Code extension that turns natural-language requests into code changes.",
+  "long_description": "Developed by Kilo Labs, the extension plans code changes, edits files, runs tests, and opens pull requests. It's freely available on the VS Code Marketplace with one-click installation."
 }

--- a/agents/Kilo/persona_ratings_kilo.json
+++ b/agents/Kilo/persona_ratings_kilo.json
@@ -4,8 +4,8 @@
     "reasoning": "Kilo can plan tasks, modify code, run tests, and open pull requests, automating significant portions of the development workflow."
   },
   "beginner_friendly_onboarding": {
-    "rating": 2,
-    "reasoning": "The service is invite-only and requires connecting a GitHub repository, which is less approachable for casual users."
+    "rating": 4,
+    "reasoning": "Kilo is an open-source VS Code extension that installs with one click, though users still need basic Git and API key setup."
   },
   "code_quality_testing": {
     "rating": 4,

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -490,8 +490,8 @@
       "task_success_rate": null,
       "resource_usage": null
     },
-    "description": "Kilo is an AI software engineering agent that connects to GitHub and implements tasks from natural-language prompts.",
-    "long_description": "Developed by Kilo Labs, the agent plans code changes, edits files, runs tests, and opens pull requests. It is currently available in a closed beta."
+    "description": "Kilo is an open-source VS Code extension that turns natural-language requests into code changes.",
+    "long_description": "Developed by Kilo Labs, the extension plans code changes, edits files, runs tests, and opens pull requests. It's freely available on the VS Code Marketplace with one-click installation."
   },
   {
     "name": "manus",

--- a/website/public/persona_ratings.json
+++ b/website/public/persona_ratings.json
@@ -1127,8 +1127,8 @@
       "reasoning": "Kilo can plan tasks, modify code, run tests, and open pull requests, automating significant portions of the development workflow."
     },
     "beginner_friendly_onboarding": {
-      "rating": 2,
-      "reasoning": "The service is invite-only and requires connecting a GitHub repository, which is less approachable for casual users."
+      "rating": 4,
+      "reasoning": "Kilo is an open-source VS Code extension that installs with one click, though users still need basic Git and API key setup."
     },
     "code_quality_testing": {
       "rating": 4,


### PR DESCRIPTION
## Summary
- correct Kilo's beginner onboarding rating to reflect one-click VS Code install
- describe Kilo as open-source VS Code extension in profile and website data

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f97d2c66483219029b03942c6c4fc