### PR TITLE
Load mini-SWE-agent persona ratings and add description

### DIFF
--- a/agents/mini-SWE-agent/agent_mini-SWE-agent.json
+++ b/agents/mini-SWE-agent/agent_mini-SWE-agent.json
@@ -16,5 +16,7 @@
     "swe_bench_source": "https://swe-agent.com/",
     "task_success_rate": null,
     "resource_usage": ""
-  }
+  },
+  "description": "A 100-line open-source coding agent that autonomously fixes GitHub issues, offering a minimal, hackable alternative to SWE-agent.",
+  "long_description": "mini-SWE-agent condenses the core workflow of SWE-agent into roughly a hundred lines of Python. Built by the Princeton and Stanford team behind SWE-bench, it reads repositories, plans edits, applies patches, runs tests, and can open pull requests. The lightweight design makes it easy to customize and deploy while still solving around 65% of SWE-bench Verified tasks."
 }

--- a/agents/mini-SWE-agent/profile.md
+++ b/agents/mini-SWE-agent/profile.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-mini-SWE-agent is a lightweight version of SWE-agent, implemented in just 100 lines of code. It is designed to be a simple and hackable agent for fixing issues in real GitHub repositories.
+mini-SWE-agent condenses the core workflow of SWE-agent into roughly 100 lines of Python. Built by the Princeton and Stanford team behind SWE-bench, it reads repositories, plans changes, edits files, runs tests, and can open pull requests. The minimal footprint makes it easy to inspect, customize, and deploy while still resolving about 65% of SWE-bench Verified issues.
 
 ## Key Information
 

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -395,7 +395,8 @@
       "task_success_rate": null,
       "resource_usage": ""
     },
-    "description": "mini-SWE-agent is a lightweight version of SWE-agent, implemented in just 100 lines of code. It is designed to be a simple and hackable agent for fixing issues in real GitHub repositories."
+    "description": "A 100-line open-source coding agent that autonomously fixes GitHub issues, offering a minimal, hackable alternative to SWE-agent.",
+    "long_description": "mini-SWE-agent condenses the core workflow of SWE-agent into roughly a hundred lines of Python. Built by the Princeton and Stanford team behind SWE-bench, it reads repositories, plans edits, applies patches, runs tests, and can open pull requests. The lightweight design makes it easy to customize and deploy while still solving around 65% of SWE-bench Verified tasks."
   },
   {
     "name": "Figma Make",

--- a/website/public/agents.json.bak
+++ b/website/public/agents.json.bak
@@ -395,7 +395,8 @@
       "task_success_rate": null,
       "resource_usage": ""
     },
-    "description": "mini-SWE-agent is a lightweight version of SWE-agent, implemented in just 100 lines of code. It is designed to be a simple and hackable agent for fixing issues in real GitHub repositories."
+    "description": "A 100-line open-source coding agent that autonomously fixes GitHub issues, offering a minimal, hackable alternative to SWE-agent.",
+    "long_description": "mini-SWE-agent condenses the core workflow of SWE-agent into roughly a hundred lines of Python. Built by the Princeton and Stanford team behind SWE-bench, it reads repositories, plans edits, applies patches, runs tests, and can open pull requests. The lightweight design makes it easy to customize and deploy while still solving around 65% of SWE-bench Verified tasks."
   },
   {
     "name": "Figma Make",

--- a/website/public/persona_ratings.json
+++ b/website/public/persona_ratings.json
@@ -1393,7 +1393,7 @@
       "reasoning": "Copilot can trigger actions across Microsoft services and plug-ins, offering moderate workflow orchestration inside the Microsoft ecosystem."
     }
   },
-  "mini-swe-agent": {
+  "mini_swe_agent": {
     "automation_productivity": {
       "rating": 3,
       "reasoning": "Research to be done."


### PR DESCRIPTION
## Summary
- fix persona ratings key for mini-SWE-agent so ratings display on solution details page
- add rich description and long description for mini-SWE-agent across metadata and profile

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f98b6060483218868f0d595a4e777