### PR TITLE
Fix persona ratings lookup for Swarm agent pages

### DIFF
--- a/website/src/components/AgentDetailModal.jsx
+++ b/website/src/components/AgentDetailModal.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { getAgentKey } from "../utils/getAgentKey";
 
 function AgentDetailModal({ agent, onClose }) {
   const [ratings, setRatings] = useState({});
@@ -38,14 +39,6 @@ function AgentDetailModal({ agent, onClose }) {
     const empty = "☆".repeat(5 - rating);
     return filled + empty;
   };
-
-    const getAgentKey = (name) => {
-      if (!name) return "";
-      return name
-        .toLowerCase()
-        .replace(/\s+/g, "_")
-        .replace(/[^a-z0-9._]/g, "_");
-    };
 
   const agentKey = getAgentKey(agent.name);
   const agentRatings = ratings[agentKey] || {};

--- a/website/src/components/AgentTable.jsx
+++ b/website/src/components/AgentTable.jsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   useImperativeHandle,
 } from "react";
+import { getAgentKey } from "../utils/getAgentKey";
 
 const AgentTable = forwardRef(function AgentTable(
   {
@@ -86,16 +87,6 @@ const AgentTable = forwardRef(function AgentTable(
         a.name.toLowerCase().includes(searchTerm.toLowerCase())
       )
     : filteredByNames;
-
-  const getAgentKey = (name) => {
-    if (!name) return "";
-    const lower = name.toLowerCase();
-    const base = lower.split(".")[0];
-    const withSpaces = base.replace(/\s+/g, "_");
-    const sanitized = withSpaces.replace(/[^a-z0-9_]/g, "_");
-    const candidates = [sanitized, lower, withSpaces];
-    return candidates.find((k) => ratings[k]) || sanitized;
-  };
 
   const computeAverage = (agent) => {
     const key = getAgentKey(agent.name);

--- a/website/src/utils/getAgentKey.js
+++ b/website/src/utils/getAgentKey.js
@@ -1,0 +1,7 @@
+export function getAgentKey(name) {
+  if (!name) return "";
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_|_$/g, "");
+}


### PR DESCRIPTION
## Summary
- add shared `getAgentKey` utility to generate consistent rating keys
- use shared key generation in agent detail modal and table so persona ratings load for OpenAI Agents SDK (Swarm)

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f99a17f5c8321b0df17d61278a316