### PR TITLE
Add Pydantic AI description

### DIFF
--- a/agents/Pydantic_AI/agent_Pydantic_AI.json
+++ b/agents/Pydantic_AI/agent_Pydantic_AI.json
@@ -20,6 +20,8 @@
     "Mistral"
   ],
   "pricing_model": "Open Source (MIT)",
+  "description": "Open-source Python framework that applies Pydantic's type validation to building structured, model-agnostic LLM agents.",
+  "long_description": "Created by the team behind Pydantic, Pydantic AI brings FastAPI-style ergonomics to building LLM agents. The open-source framework validates structured outputs with Pydantic models, works with a wide range of providers, ties into Logfire for monitoring, and offers optional dependency injection, streaming responses, and graph-based workflow composition for production-grade applications.",
   "benchmarks": {
     "swe_bench_score": null,
     "task_success_rate": null,

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -1477,6 +1477,8 @@
       "Mistral"
     ],
     "pricing_model": "Open Source (MIT)",
+    "description": "Open-source Python framework that applies Pydantic's type validation to building structured, model-agnostic LLM agents.",
+    "long_description": "Created by the team behind Pydantic, Pydantic AI brings FastAPI-style ergonomics to building LLM agents. The open-source framework validates structured outputs with Pydantic models, works with a wide range of providers, ties into Logfire for monitoring, and offers optional dependency injection, streaming responses, and graph-based workflow composition for production-grade applications.",
     "benchmarks": {
       "swe_bench_score": null,
       "task_success_rate": null,

--- a/website/public/agents.json.bak
+++ b/website/public/agents.json.bak
@@ -1477,6 +1477,8 @@
       "Mistral"
     ],
     "pricing_model": "Open Source (MIT)",
+    "description": "Open-source Python framework that applies Pydantic's type validation to building structured, model-agnostic LLM agents.",
+    "long_description": "Created by the team behind Pydantic, Pydantic AI brings FastAPI-style ergonomics to building LLM agents. The open-source framework validates structured outputs with Pydantic models, works with a wide range of providers, ties into Logfire for monitoring, and offers optional dependency injection, streaming responses, and graph-based workflow composition for production-grade applications.",
     "benchmarks": {
       "swe_bench_score": null,
       "task_success_rate": null,


### PR DESCRIPTION
## Summary
- add short and long descriptions for Pydantic AI metadata

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f9a6619088321b6a66d51ae3cccff