### PR TITLE
Add Semantic Kernel description

### DIFF
--- a/agents/Semantic_Kernel/agent_Semantic_Kernel.json
+++ b/agents/Semantic_Kernel/agent_Semantic_Kernel.json
@@ -19,5 +19,7 @@
     "swe_bench_score": null,
     "task_success_rate": null,
     "resource_usage": ""
-  }
+  },
+  "description": "Semantic Kernel is an open-source SDK by Microsoft for building AI agents and multi-agent systems.",
+  "long_description": "It provides a modular skill library, planners, and connectors to integrate language models into applications with memory and tool use, and it powers products like Microsoft 365 Copilot."
 }

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -1380,7 +1380,9 @@
       "swe_bench_score": null,
       "task_success_rate": null,
       "resource_usage": ""
-    }
+    },
+    "description": "Semantic Kernel is an open-source SDK by Microsoft for building AI agents and multi-agent systems.",
+    "long_description": "It provides a modular skill library, planners, and connectors to integrate language models into applications with memory and tool use, and it powers products like Microsoft 365 Copilot."
   },
   {
     "name": "OpenAI Agents SDK (Swarm)",

--- a/website/public/agents.json.bak
+++ b/website/public/agents.json.bak
@@ -1380,7 +1380,9 @@
       "swe_bench_score": null,
       "task_success_rate": null,
       "resource_usage": ""
-    }
+    },
+    "description": "Semantic Kernel is an open-source SDK by Microsoft for building AI agents and multi-agent systems.",
+    "long_description": "It provides a modular skill library, planners, and connectors to integrate language models into applications with memory and tool use, and it powers products like Microsoft 365 Copilot."
   },
   {
     "name": "OpenAI Agents SDK (Swarm)",


### PR DESCRIPTION
## Summary
- provide short and long descriptions for the Semantic Kernel agent
- surface description in generated agents list for the website

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f9ac3e49c8321a2e1a7fc8a504367