### PR TITLE
Add Wireframer agent and website data

### DIFF
--- a/agents/Wireframer/agent_Wireframer.json
+++ b/agents/Wireframer/agent_Wireframer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Wireframer",
+  "website": "https://www.framer.com/wireframer/",
+  "developer": "Framer",
+  "key_features": [
+    "Generates responsive wireframes from a single text prompt",
+    "Produces clean layouts focused on hierarchy and flow",
+    "Desktop-based design tool"
+  ],
+  "supported_models": [
+    "Proprietary model"
+  ],
+  "pricing_model": "Free plan available with paid upgrades",
+  "benchmarks": {
+    "swe_bench_score": null,
+    "task_success_rate": null,
+    "resource_usage": ""
+  },
+  "description": "Wireframer by Framer converts prompts into structured, responsive pages.",
+  "long_description": "Wireframer generates clean, responsive layouts focused on hierarchy and flow, giving designers a solid foundation without locking them into a look."
+}

--- a/agents/Wireframer/persona_ratings_wireframer.json
+++ b/agents/Wireframer/persona_ratings_wireframer.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 3,
+    "reasoning": "Generates full page wireframes from a prompt, automating initial layout work."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 4,
+    "reasoning": "Requires only a single prompt to start and runs in the Framer desktop app."
+  },
+  "code_quality_testing": {
+    "rating": 1,
+    "reasoning": "Designed for UI layout, not code testing."
+  },
+  "codebase_comprehension": {
+    "rating": 1,
+    "reasoning": "Does not interact with codebases."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 2,
+    "reasoning": "Focuses on visual layout generation with limited multimodal capabilities."
+  },
+  "data_experimental_flexibility": {
+    "rating": 1,
+    "reasoning": "No support for data analysis or experiment tracking."
+  },
+  "visual_no_code_development": {
+    "rating": 4,
+    "reasoning": "Produces visual layouts without coding, giving a starting point for design."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 1,
+    "reasoning": "Operates as a standalone design assistant without orchestration features."
+  }
+}

--- a/agents/Wireframer/profile.md
+++ b/agents/Wireframer/profile.md
@@ -1,0 +1,12 @@
+# Wireframer
+
+Wireframer is an AI-powered tool from Framer that transforms a single prompt into a fully structured, responsive page, complete with layout and navigation. It generates clean, responsive layouts focused on hierarchy and flow, giving designers a solid foundation without locking them into a specific look.
+
+## Key Features
+- Prompt-based generation of responsive page structures
+- Clean layouts emphasizing hierarchy and flow
+- Available as a desktop tool within Framer
+
+## References
+- [Wireframer website](https://www.framer.com/wireframer/)
+- [Framer Pricing](https://www.framer.com/pricing)

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -1619,5 +1619,26 @@
     },
     "description": "AutoGPT is a platform for creating and managing continuous AI agents that automate complex workflows.",
     "long_description": "AutoGPT began as an experimental project to demonstrate autonomous GPT-4 operation, showcasing goal decomposition, tool use, memory and self-prompting. It has evolved into a platform for building, deploying and monitoring agents with benchmarking and UI support."
+  },
+  {
+    "name": "Wireframer",
+    "website": "https://www.framer.com/wireframer/",
+    "developer": "Framer",
+    "key_features": [
+      "Generates responsive wireframes from a single text prompt",
+      "Produces clean layouts focused on hierarchy and flow",
+      "Desktop-based design tool"
+    ],
+    "supported_models": [
+      "Proprietary model"
+    ],
+    "pricing_model": "Free plan available with paid upgrades",
+    "benchmarks": {
+      "swe_bench_score": null,
+      "task_success_rate": null,
+      "resource_usage": ""
+    },
+    "description": "Wireframer by Framer converts prompts into structured, responsive pages.",
+    "long_description": "Wireframer generates clean, responsive layouts focused on hierarchy and flow, giving designers a solid foundation without locking them into a look."
   }
 ]

--- a/website/public/persona_ratings.json
+++ b/website/public/persona_ratings.json
@@ -2242,5 +2242,40 @@
       "rating": 4,
       "reasoning": "Handles multi-step processes with branching, scheduling, and AI-driven actions, providing strong orchestration capabilities."
     }
+  },
+  "wireframer": {
+    "automation_productivity": {
+      "rating": 3,
+      "reasoning": "Generates full page wireframes from a prompt, automating initial layout work."
+    },
+    "beginner_friendly_onboarding": {
+      "rating": 4,
+      "reasoning": "Requires only a single prompt to start and runs in the Framer desktop app."
+    },
+    "code_quality_testing": {
+      "rating": 1,
+      "reasoning": "Designed for UI layout, not code testing."
+    },
+    "codebase_comprehension": {
+      "rating": 1,
+      "reasoning": "Does not interact with codebases."
+    },
+    "creative_multimodal_exploration": {
+      "rating": 2,
+      "reasoning": "Focuses on visual layout generation with limited multimodal capabilities."
+    },
+    "data_experimental_flexibility": {
+      "rating": 1,
+      "reasoning": "No support for data analysis or experiment tracking."
+    },
+    "visual_no_code_development": {
+      "rating": 4,
+      "reasoning": "Produces visual layouts without coding, giving a starting point for design."
+    },
+    "workflow_agent_orchestration": {
+      "rating": 1,
+      "reasoning": "Operates as a standalone design assistant without orchestration features."
+    }
   }
 }
+


### PR DESCRIPTION
## Summary
- add Wireframer (framer.com) agent profile and ratings
- expose Wireframer details to website datasets

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a39929db088321a05b3bed6ded244f