### PR TITLE
Add Abacus.AI profile and surface on website

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The following agents have been profiled in this repository:
 - v0.app (`agents/v0.app`)
 - n8n (`agents/n8n`)
 - Zapier (`agents/Zapier`)
+- Abacus.AI (`agents/Abacus.ai`)
 - AgentGPT (`agents/AgentGPT`)
 - Fixie.ai (`agents/Fixie.ai`)
 - IBM watsonx Orchestrate (`agents/IBM_watsonx_Orchestrate`)

--- a/agents/Abacus.ai/agent_Abacus.ai.json
+++ b/agents/Abacus.ai/agent_Abacus.ai.json
@@ -1,0 +1,26 @@
+{
+  "name": "Abacus.AI",
+  "website": "https://abacus.ai/",
+  "developer": "Abacus.AI",
+  "key_features": [
+    "DeepAgent general-purpose assistant that can build applications, presentations, and automated workflows from natural language prompts",
+    "Modular solutions for ChatLLM, Code LLM, document intelligence, forecasting and planning, anomaly detection, and marketing personalization",
+    "Unified platform for combining real-time data pipelines with retrieval-augmented generation over enterprise knowledge bases",
+    "No-code workflow orchestration with integrations for popular SaaS, databases, and event streams",
+    "Enterprise-grade security, guardrails, and monitoring to manage AI deployments at scale"
+  ],
+  "supported_models": [
+    "Abacus.AI foundation models",
+    "OpenAI GPT-4 family",
+    "Anthropic Claude models",
+    "Google Gemini models",
+    "Cohere Command models"
+  ],
+  "pricing_model": "Enterprise plans with custom pricing; consultation required",
+  "benchmarks": {
+    "swe_bench_score": null,
+    "task_success_rate": null,
+    "resource_usage": ""
+  },
+  "description": "Abacus.AI is an enterprise platform that pairs a general-purpose DeepAgent with modular AI solutions so organizations can launch chatbots, forecasting systems, and personalized workflows on their own data."
+}

--- a/agents/Abacus.ai/persona_ratings_abacus_ai.json
+++ b/agents/Abacus.ai/persona_ratings_abacus_ai.json
@@ -1,0 +1,34 @@
+{
+  "automation_productivity": {
+    "rating": 4,
+    "reasoning": "DeepAgent automates multi-step enterprise workflows, letting teams deploy chatbots, forecasting flows, and marketing journeys without hand coding each task."
+  },
+  "beginner_friendly_onboarding": {
+    "rating": 2,
+    "reasoning": "Setup typically involves a sales-assisted onboarding to connect data sources and configure guardrails, which is heavier than self-serve tools."
+  },
+  "code_quality_testing": {
+    "rating": 1,
+    "reasoning": "The platform targets business AI applications and does not provide dedicated code quality or testing features."
+  },
+  "codebase_comprehension": {
+    "rating": 1,
+    "reasoning": "Abacus.AI is not designed for navigating or understanding existing software codebases."
+  },
+  "creative_multimodal_exploration": {
+    "rating": 3,
+    "reasoning": "DeepAgent can generate apps, presentations, and other assets, and the Document Intelligence modules support multimodal use cases."
+  },
+  "data_experimental_flexibility": {
+    "rating": 4,
+    "reasoning": "Modular solutions span personalization, anomaly detection, forecasting, and marketing analytics, and they ingest enterprise data streams for experimentation."
+  },
+  "visual_no_code_development": {
+    "rating": 3,
+    "reasoning": "The workflow builder offers a visual environment for composing automations, though advanced deployments still rely on technical configuration."
+  },
+  "workflow_agent_orchestration": {
+    "rating": 4,
+    "reasoning": "DeepAgent and the orchestration layer coordinate multi-step processes with guardrails, enabling sophisticated enterprise automations."
+  }
+}

--- a/agents/Abacus.ai/profile.md
+++ b/agents/Abacus.ai/profile.md
@@ -1,0 +1,39 @@
+# Abacus.AI
+
+## Overview
+
+Abacus.AI is an enterprise AI platform that combines a general-purpose agent, branded as DeepAgent, with a catalog of modular AI solutions. Teams can launch custom chatbots, document understanding flows, personalized marketing, forecasting, anomaly detection, and code-oriented assistants while grounding outputs on their organization's data.
+
+## Key Information
+
+- **Developer:** Abacus.AI
+- **Website:** [https://abacus.ai/](https://abacus.ai/)
+- **Pricing:** Enterprise plans with custom pricing; consultation required
+
+## Key Features
+
+- DeepAgent general assistant that turns natural language prompts into apps, presentations, and automated workflows
+- Modular offerings covering ChatLLM, Code LLM, Document Intelligence, Forecasting & Planning, Anomaly Detection, and Marketing & Growth personalization
+- Retrieval-augmented generation powered by knowledge ingestion, embeddings, and vector search over enterprise content
+- No-code workflow orchestration layer with connectors for SaaS tools, databases, and event streams
+- Enterprise guardrails, monitoring, and security controls to operate AI experiences at scale
+
+## Supported Models
+
+- Abacus.AI foundation models
+- OpenAI GPT-4 family
+- Anthropic Claude models
+- Google Gemini models
+- Cohere Command models
+
+## Benchmarks
+
+- **SWE-bench score:** Not available
+- **Task Success Rate:** Not available
+- **Resource Usage:** Not available
+
+## Qualitative Assessment
+
+- **Ease of Use:** Designed for enterprise solution builders; visual workflow tools help but implementation still requires planning around data pipelines and governance.
+- **Documentation Quality:** Product documentation and solution playbooks cover the modular use cases, though some advanced integrations rely on guided onboarding.
+- **Onboarding Experience:** Sales-assisted onboarding pairs teams with Abacus.AI experts to connect data sources and configure guardrails before handing off to self-service management.

--- a/website/public/agents.json
+++ b/website/public/agents.json
@@ -1290,6 +1290,36 @@
     "description": "Fixie.ai is a platform for building and hosting AI agents that connect to external tools and data sources, enabling organizations to automate workflows and deploy conversational assistants."
   },
   {
+    "name": "Abacus.AI",
+    "website": "https://abacus.ai/",
+    "developer": "Abacus.AI",
+    "key_features": [
+      "DeepAgent general-purpose assistant that generates applications, presentations, and automated workflows from natural language prompts",
+      "Catalog of modular solutions spanning ChatLLM, Code LLM, Document Intelligence, Forecasting & Planning, Anomaly Detection, and Marketing & Growth personalization",
+      "Retrieval-augmented generation that blends real-time data pipelines with knowledge bases and vector search",
+      "No-code workflow orchestration and integrations for popular SaaS platforms, databases, and streaming data",
+      "Enterprise-grade guardrails, monitoring, and governance controls for large-scale AI deployments"
+    ],
+    "supported_models": [
+      "Abacus.AI foundation models",
+      "OpenAI GPT-4 family",
+      "Anthropic Claude models",
+      "Google Gemini models",
+      "Cohere Command models"
+    ],
+    "pricing_model": "Enterprise plans with custom pricing; consultation required.",
+    "benchmarks": {
+      "swe_bench_score": null,
+      "swe_bench_source": null,
+      "terminal_bench_score": null,
+      "terminal_bench_source": null,
+      "task_success_rate": null,
+      "resource_usage": null
+    },
+    "description": "Abacus.AI is an enterprise platform that combines its DeepAgent assistant with modular AI solutions so organizations can deploy chatbots, forecasting systems, and personalized workflows on their data.",
+    "long_description": "Abacus.AI provides an end-to-end environment for grounding large language models on enterprise knowledge, orchestrating workflows through DeepAgent, and deploying targeted solutions such as Document Intelligence, Marketing & Growth personalization, anomaly detection, forecasting, and code-focused assistants—all secured with enterprise guardrails and monitoring."
+  },
+  {
     "name": "BabyAGI",
     "website": "https://github.com/yoheinakajima/babyagi",
     "developer": "Yohei Nakajima",

--- a/website/public/persona_ratings.json
+++ b/website/public/persona_ratings.json
@@ -33,6 +33,40 @@
       "reasoning": "Designed for single-agent operation without advanced multi-agent orchestration."
     }
   },
+  "abacus_ai": {
+    "automation_productivity": {
+      "rating": 4,
+      "reasoning": "DeepAgent automates multi-step enterprise workflows, letting teams deploy chatbots, forecasting flows, and marketing journeys without hand coding each task."
+    },
+    "beginner_friendly_onboarding": {
+      "rating": 2,
+      "reasoning": "Setup typically involves a sales-assisted onboarding to connect data sources and configure guardrails, which is heavier than self-serve tools."
+    },
+    "code_quality_testing": {
+      "rating": 1,
+      "reasoning": "The platform targets business AI applications and does not provide dedicated code quality or testing features."
+    },
+    "codebase_comprehension": {
+      "rating": 1,
+      "reasoning": "Abacus.AI is not designed for navigating or understanding existing software codebases."
+    },
+    "creative_multimodal_exploration": {
+      "rating": 3,
+      "reasoning": "DeepAgent can generate apps, presentations, and other assets, and the Document Intelligence modules support multimodal use cases."
+    },
+    "data_experimental_flexibility": {
+      "rating": 4,
+      "reasoning": "Modular solutions span personalization, anomaly detection, forecasting, and marketing analytics, and they ingest enterprise data streams for experimentation."
+    },
+    "visual_no_code_development": {
+      "rating": 3,
+      "reasoning": "The workflow builder offers a visual environment for composing automations, though advanced deployments still rely on technical configuration."
+    },
+    "workflow_agent_orchestration": {
+      "rating": 4,
+      "reasoning": "DeepAgent and the orchestration layer coordinate multi-step processes with guardrails, enabling sophisticated enterprise automations."
+    }
+  },
   "agentverse": {
     "automation_productivity": {
       "rating": 3,


### PR DESCRIPTION
## Summary
- add Abacus.AI agent directory with structured metadata, profile, and persona ratings
- list Abacus.AI in the README and expose the agent in the website data sources
- extend website persona ratings to cover the new agent

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cbf6716ba88321b86868284e8c10e2